### PR TITLE
fix(ingest): Retry if some files are not found

### DIFF
--- a/backend/asset/copy-objects.go
+++ b/backend/asset/copy-objects.go
@@ -3,9 +3,11 @@ package asset
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ansel1/merry/v2"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/bcc-code/mediabank-bridge/log"
 	"go.opentelemetry.io/otel"
 )
@@ -30,19 +32,42 @@ func copyObjects(
 			ctx, span := tracer.Start(ctx, "copyObject")
 			defer span.End()
 
-			_, err := s3client.CopyObject(ctx, f)
+			tries := 1
+			for tries <= 3 {
+				_, err := s3client.CopyObject(ctx, f)
 
-			if err != nil {
-				log.L.Error().
-					Err(err).
-					Str("dst bucket", *f.Bucket).
-					Str("source path", *f.CopySource).
-					Str("dst path", *f.Key).
-					Msg("File copy failed")
+				if err != nil {
+					if awsErr, ok := err.(awserr.Error); ok {
+						if awsErr.Code() == "NoSuchKey" {
+							log.L.Warn().
+								Err(err).
+								Str("dst bucket", *f.Bucket).
+								Str("source path", *f.CopySource).
+								Str("dst path", *f.Key).
+								Int("tries", tries).
+								Msg("File copy failed due to missing file")
 
-				copyErrors = append(copyErrors, merry.Wrap(err))
-				return
+							// For some reason the system notifies us before the files are available
+							// so we wait a bit and try again
+							// This should be removed once https://www.notion.so/bccmedia/Export-Asset-for-Downloading-6a82bb779dd4474d910c53d36551f05f?pvs=4#eab1f760803a4b8dbf3bad487549d9a2 has been fixed
+							time.Sleep(60 * time.Second)
+							tries += 1
+							continue
+						}
+					}
+
+					log.L.Error().
+						Err(err).
+						Str("dst bucket", *f.Bucket).
+						Str("source path", *f.CopySource).
+						Str("dst path", *f.Key).
+						Msg("File copy failed")
+
+					copyErrors = append(copyErrors, merry.Wrap(err))
+					return
+				}
 			}
+
 			log.L.Info().
 				Str("dst bucket", *f.Bucket).
 				Str("source path", *f.CopySource).
@@ -50,6 +75,7 @@ func copyObjects(
 				Msg("File copied")
 		}()
 	}
+
 	wg.Wait()
 	return copyErrors
 }


### PR DESCRIPTION
Currently MB notifies us before it has concluded uploading the files so we retry after a minute up to 3 times total. Timeout on worker is 600s, so there should be plenty of time