### PR TITLE
fix(asset import): Allow longer retry times

### DIFF
--- a/backend/directus/client.go
+++ b/backend/directus/client.go
@@ -3,6 +3,7 @@ package directus
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"strconv"
 
@@ -30,7 +31,7 @@ func New(url, key string, debug bool) *resty.Client {
 		SetBaseURL(url).
 		SetAuthToken(key).
 		SetRetryCount(10).
-		SetRetryMaxWaitTime(15).
+		SetRetryMaxWaitTime(15 * time.Second).
 		EnableTrace().
 		SetDebug(false)
 	return rest

--- a/backend/directus/client.go
+++ b/backend/directus/client.go
@@ -30,6 +30,7 @@ func New(url, key string, debug bool) *resty.Client {
 		SetBaseURL(url).
 		SetAuthToken(key).
 		SetRetryCount(5).
+		SetRetryMaxWaitTime(10).
 		EnableTrace().
 		SetDebug(false)
 	return rest

--- a/backend/directus/client.go
+++ b/backend/directus/client.go
@@ -29,8 +29,8 @@ func New(url, key string, debug bool) *resty.Client {
 	rest := resty.New().
 		SetBaseURL(url).
 		SetAuthToken(key).
-		SetRetryCount(5).
-		SetRetryMaxWaitTime(10).
+		SetRetryCount(10).
+		SetRetryMaxWaitTime(15).
 		EnableTrace().
 		SetDebug(false)
 	return rest

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,6 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.4 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,6 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/auth0/go-jwt-middleware/v2 v2.1.0 h1:VU4LsC3aFPoqXVyEp8EixU6FNM+ZNIjECszRTvtGQI8=
 github.com/auth0/go-jwt-middleware/v2 v2.1.0/go.mod h1:CpzcJoleayAACpv+vt0AP8/aYn5TDngsqzLapV1nM4c=
-github.com/aws/aws-sdk-go v1.44.295 h1:SGjU1+MqttXfRiWHD6WU0DRhaanJgAFY+xIhEaugV8Y=
-github.com/aws/aws-sdk-go v1.44.295/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go v1.44.296 h1:ALRZIIKI+6EBWDiWP4RHWmOtHZ7dywRzenL4NWgNI2A=
 github.com/aws/aws-sdk-go v1.44.296/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.18.1 h1:+tefE750oAb7ZQGzla6bLkOwfcQCEtC5y2RqoqCeqKo=


### PR DESCRIPTION
The new Directus version currently employs a load shedding system (under pressure errors) that appears to be really agrssive. This causes more fails than needed. Attempt to mitigate this by allowing the client to space out retries over a longer period. Default is 2s, increased to 10s.