### PR TITLE
feat(cursor): append related items to next

### DIFF
--- a/backend/graph/api/episode-resolver.utils.go
+++ b/backend/graph/api/episode-resolver.utils.go
@@ -268,7 +268,7 @@ func (r *episodeResolver) getRelatedEpisodeIDs(ctx context.Context, episodeID st
 	}, []int{})
 	// Uncomment if we want all episodes to be treated equally.
 	// Keep it commented out to weigh episode with more common tags higher.
-	episodeIDs = lo.Uniq(episodeIDs)
+	//episodeIDs = lo.Uniq(episodeIDs)
 	episodeIDs = lo.Filter(episodeIDs, func(i int, _ int) bool {
 		return i != intID
 	})

--- a/backend/graph/api/episode-resolver.utils.go
+++ b/backend/graph/api/episode-resolver.utils.go
@@ -184,7 +184,7 @@ func (r *episodeResolver) getNextEpisodes(ctx context.Context, episodeID string,
 		l = *limit
 	}
 
-	keys := cursor.NextKeys(l)
+	keys := cursor.NextKeys(1)
 	if len(keys) < l {
 		appendIDs := func(ids []int) {
 			ids = lo.Shuffle(ids)

--- a/backend/graph/api/episode-resolver.utils.go
+++ b/backend/graph/api/episode-resolver.utils.go
@@ -13,7 +13,6 @@ import (
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
 	"gopkg.in/guregu/null.v4"
-	"math/rand"
 	"strconv"
 )
 
@@ -180,28 +179,51 @@ func (r *episodeResolver) getNextEpisodes(ctx context.Context, episodeID string,
 		return nil, err
 	}
 
-	next := cursor.NextCursor()
-	if next == nil {
-		ids, err := r.getNextFromShowCollection(ctx, episodeID)
-		if err != nil {
-			return nil, err
-		}
-		if len(ids) > 0 {
-			return ids, nil
-		}
-		return r.getRelatedEpisodes(ctx, episodeID)
-	}
-
 	l := 1
 	if limit != nil {
 		l = *limit
 	}
 
-	return cursor.NextKeys(l), nil
+	keys := cursor.NextKeys(l)
+	if len(keys) < l {
+		appendIDs := func(ids []int) {
+			ids = lo.Shuffle(ids)
+			for _, id := range ids {
+				if !lo.Contains(keys, id) {
+					keys = append(keys, id)
+				}
+				if len(keys) >= l {
+					return
+				}
+			}
+		}
+
+		var ids []int
+		ids, err = r.getNextEpisodeIDsFromShowCollection(ctx, episodeID)
+		if err != nil {
+			return nil, err
+		}
+
+		appendIDs(ids)
+		if len(keys) >= l {
+			return keys, nil
+		}
+
+		ids, err = r.getRelatedEpisodeIDs(ctx, episodeID)
+		if err != nil {
+			return nil, err
+		}
+
+		appendIDs(ids)
+		if len(keys) >= l {
+			return keys, nil
+		}
+	}
+	return keys, nil
 }
 
-func (r *episodeResolver) getNextFromShowCollection(ctx context.Context, episodeID string) ([]int, error) {
-	ctx, span := otel.Tracer("episode-resolver").Start(ctx, "getNextFromShowCollection")
+func (r *episodeResolver) getNextEpisodeIDsFromShowCollection(ctx context.Context, episodeID string) ([]int, error) {
+	ctx, span := otel.Tracer("episode-resolver").Start(ctx, "getNextEpisodeIDsFromShowCollection")
 	defer span.End()
 	intID := utils.AsInt(episodeID)
 	episode, err := r.Loaders.EpisodeLoader.Get(ctx, intID)
@@ -220,20 +242,17 @@ func (r *episodeResolver) getNextFromShowCollection(ctx context.Context, episode
 	if err != nil {
 		return nil, err
 	}
-	episodeEntries := lo.Filter(entries, func(i collection.Entry, _ int) bool {
-		return i.Collection == common.CollectionEpisodes && i.ID != episodeID
-	})
-	if len(episodeEntries) <= 0 {
-		return nil, nil
+	var episodeIDs []int
+	for _, i := range entries {
+		if i.Collection == common.CollectionEpisodes && i.ID != episodeID {
+			episodeIDs = append(episodeIDs, utils.AsInt(i.ID))
+		}
 	}
-	randomIndex := rand.Intn(len(episodeEntries))
-	return []int{
-		utils.AsInt(episodeEntries[randomIndex].ID),
-	}, nil
+	return episodeIDs, nil
 }
 
-func (r *episodeResolver) getRelatedEpisodes(ctx context.Context, episodeID string) ([]int, error) {
-	ctx, span := otel.Tracer("episode-resolver").Start(ctx, "getRelatedEpisodes")
+func (r *episodeResolver) getRelatedEpisodeIDs(ctx context.Context, episodeID string) ([]int, error) {
+	ctx, span := otel.Tracer("episode-resolver").Start(ctx, "getRelatedEpisodeIDs")
 	defer span.End()
 	intID := utils.AsInt(episodeID)
 	episode, err := r.Loaders.EpisodeLoader.Get(ctx, intID)
@@ -249,15 +268,14 @@ func (r *episodeResolver) getRelatedEpisodes(ctx context.Context, episodeID stri
 	}, []int{})
 	// Uncomment if we want all episodes to be treated equally.
 	// Keep it commented out to weigh episode with more common tags higher.
-	//episodeIDs = lo.Uniq(episodeIDs)
+	episodeIDs = lo.Uniq(episodeIDs)
 	episodeIDs = lo.Filter(episodeIDs, func(i int, _ int) bool {
 		return i != intID
 	})
 	if len(episodeIDs) <= 0 {
 		return nil, nil
 	}
-	randomIndex := rand.Intn(len(episodeIDs))
-	return []int{episodeIDs[randomIndex]}, nil
+	return episodeIDs, nil
 }
 
 func (r *episodeResolver) getTitleFromContext(ctx context.Context, obj *model.Episode) (string, error) {

--- a/backend/graph/api/episode-resolver.utils.go
+++ b/backend/graph/api/episode-resolver.utils.go
@@ -171,7 +171,7 @@ func (r *episodeResolver) getEpisodeCursor(ctx context.Context, episodeID string
 	})
 }
 
-func appendNextEpisodeIDs(keys []int, ids []int) []int {
+func appendShuffledKeys[K comparable](keys []K, ids []K) []K {
 	ids = lo.Shuffle(ids)
 	for _, id := range ids {
 		if !lo.Contains(keys, id) {
@@ -202,7 +202,7 @@ func (r *episodeResolver) getNextEpisodes(ctx context.Context, episodeID string,
 			return nil, err
 		}
 
-		keys = appendNextEpisodeIDs(keys, ids)
+		keys = appendShuffledKeys(keys, ids)
 		if len(keys) >= l {
 			return keys, nil
 		}
@@ -212,7 +212,7 @@ func (r *episodeResolver) getNextEpisodes(ctx context.Context, episodeID string,
 			return nil, err
 		}
 
-		keys = appendNextEpisodeIDs(keys, ids)
+		keys = appendShuffledKeys(keys, ids)
 		if len(keys) >= l {
 			return keys, nil
 		}


### PR DESCRIPTION
Add related items to next when the current queue is ended. 

Basically when the cursor is over, it will add items from the related collection (configured on show level) or episodes with similar tags. 

If there's no related collection and no related episodes, no items will be added when cursor is ended.

Recommended practice is to use the episode cursor retrieved on the original/root episode, and not the cursor inside the next episodes.