### PR TITLE
fix: limit next episodes

### DIFF
--- a/backend/graph/api/episode-resolver.utils.go
+++ b/backend/graph/api/episode-resolver.utils.go
@@ -204,7 +204,7 @@ func (r *episodeResolver) getNextEpisodes(ctx context.Context, episodeID string,
 
 		keys = appendShuffledKeys(keys, ids)
 		if len(keys) >= l {
-			return keys, nil
+			return keys[:l], nil
 		}
 
 		ids, err = r.getRelatedEpisodeIDs(ctx, episodeID)
@@ -214,7 +214,7 @@ func (r *episodeResolver) getNextEpisodes(ctx context.Context, episodeID string,
 
 		keys = appendShuffledKeys(keys, ids)
 		if len(keys) >= l {
-			return keys, nil
+			return keys[:l], nil
 		}
 	}
 	return keys, nil


### PR DESCRIPTION
otherwise we would need to rename to `targetAmount` or something (:
which miight be better because the backend has more control but lets stick with this for now