### PR TITLE
chore(db-cleanup): remove unused tables and fix indexes

### DIFF
--- a/backend/asset/ingest.go
+++ b/backend/asset/ingest.go
@@ -449,8 +449,8 @@ func Ingest(ctx context.Context, services externalServices, config config, event
 
 			for _, l := range audioLanguages {
 				_, err = queries.InsertAssetStreamAudioLanguage(ctx, sqlc.InsertAssetStreamAudioLanguageParams{
-					AssetstreamsID: null.IntFrom(int64(streamID)),
-					LanguagesCode:  null.StringFrom(l),
+					AssetstreamsID: streamID,
+					LanguagesCode:  l,
 				})
 				if err != nil {
 					return merry.Wrap(err)
@@ -459,8 +459,8 @@ func Ingest(ctx context.Context, services externalServices, config config, event
 
 			for _, l := range subLanguages {
 				_, err = queries.InsertAssetStreamSubtitleLanguage(ctx, sqlc.InsertAssetStreamSubtitleLanguageParams{
-					AssetstreamsID: null.IntFrom(int64(streamID)),
-					LanguagesCode:  null.StringFrom(l),
+					AssetstreamsID: streamID,
+					LanguagesCode:  l,
 				})
 				if err != nil {
 					return merry.Wrap(err)

--- a/backend/sqlc/assets.sql.go
+++ b/backend/sqlc/assets.sql.go
@@ -158,8 +158,8 @@ RETURNING id
 `
 
 type InsertAssetStreamAudioLanguageParams struct {
-	AssetstreamsID null_v4.Int    `db:"assetstreams_id" json:"assetstreamsId"`
-	LanguagesCode  null_v4.String `db:"languages_code" json:"languagesCode"`
+	AssetstreamsID int32  `db:"assetstreams_id" json:"assetstreamsId"`
+	LanguagesCode  string `db:"languages_code" json:"languagesCode"`
 }
 
 func (q *Queries) InsertAssetStreamAudioLanguage(ctx context.Context, arg InsertAssetStreamAudioLanguageParams) (int32, error) {
@@ -176,8 +176,8 @@ RETURNING id
 `
 
 type InsertAssetStreamSubtitleLanguageParams struct {
-	AssetstreamsID null_v4.Int    `db:"assetstreams_id" json:"assetstreamsId"`
-	LanguagesCode  null_v4.String `db:"languages_code" json:"languagesCode"`
+	AssetstreamsID int32  `db:"assetstreams_id" json:"assetstreamsId"`
+	LanguagesCode  string `db:"languages_code" json:"languagesCode"`
 }
 
 func (q *Queries) InsertAssetStreamSubtitleLanguage(ctx context.Context, arg InsertAssetStreamSubtitleLanguageParams) (int32, error) {

--- a/backend/sqlc/collection-queries.go
+++ b/backend/sqlc/collection-queries.go
@@ -45,7 +45,7 @@ func (q *Queries) GetCollections(ctx context.Context, ids []int) ([]common.Colle
 
 func mapToCollectionItems(items []CollectionsEntry) []common.CollectionItem {
 	return lo.Map(items, func(i CollectionsEntry, _ int) common.CollectionItem {
-		c := common.Collections.Parse(i.Collection.ValueOrZero())
+		c := common.Collections.Parse(i.Collection)
 		if c == nil {
 			c = &common.CollectionUnknown
 		}
@@ -54,7 +54,7 @@ func mapToCollectionItems(items []CollectionsEntry) []common.CollectionItem {
 			Sort:         int(i.Sort.ValueOrZero()),
 			CollectionID: int(i.CollectionsID),
 			Type:         *c,
-			ItemID:       i.Item.ValueOrZero(),
+			ItemID:       i.Item,
 		}
 	})
 }

--- a/backend/sqlc/models.go
+++ b/backend/sqlc/models.go
@@ -35,9 +35,9 @@ type Achievementcondition struct {
 }
 
 type AchievementconditionsStudytopic struct {
-	ID                      int32         `db:"id" json:"id"`
-	AchievementconditionsID uuid.NullUUID `db:"achievementconditions_id" json:"achievementconditionsId"`
-	StudytopicsID           uuid.NullUUID `db:"studytopics_id" json:"studytopicsId"`
+	ID                      int32     `db:"id" json:"id"`
+	AchievementconditionsID uuid.UUID `db:"achievementconditions_id" json:"achievementconditionsId"`
+	StudytopicsID           uuid.UUID `db:"studytopics_id" json:"studytopicsId"`
 }
 
 type Achievementgroup struct {
@@ -60,10 +60,10 @@ type AchievementgroupsTranslation struct {
 }
 
 type AchievementsImage struct {
-	ID            uuid.UUID      `db:"id" json:"id"`
-	Image         uuid.NullUUID  `db:"image" json:"image"`
-	AchievementID uuid.NullUUID  `db:"achievement_id" json:"achievementId"`
-	Language      null_v4.String `db:"language" json:"language"`
+	ID            uuid.UUID `db:"id" json:"id"`
+	Image         uuid.UUID `db:"image" json:"image"`
+	AchievementID uuid.UUID `db:"achievement_id" json:"achievementId"`
+	Language      string    `db:"language" json:"language"`
 }
 
 type AchievementsTranslation struct {
@@ -119,9 +119,9 @@ type Applicationgroup struct {
 }
 
 type ApplicationgroupsUsergroup struct {
-	ID                  int32          `db:"id" json:"id"`
-	ApplicationgroupsID uuid.NullUUID  `db:"applicationgroups_id" json:"applicationgroupsId"`
-	UsergroupsCode      null_v4.String `db:"usergroups_code" json:"usergroupsCode"`
+	ID                  int32     `db:"id" json:"id"`
+	ApplicationgroupsID uuid.UUID `db:"applicationgroups_id" json:"applicationgroupsId"`
+	UsergroupsCode      string    `db:"usergroups_code" json:"usergroupsCode"`
 }
 
 type Asset struct {
@@ -177,19 +177,19 @@ type Assetstream struct {
 }
 
 type AssetstreamsAudioLanguage struct {
-	AssetstreamsID null_v4.Int    `db:"assetstreams_id" json:"assetstreamsId"`
-	ID             int32          `db:"id" json:"id"`
-	LanguagesCode  null_v4.String `db:"languages_code" json:"languagesCode"`
+	AssetstreamsID int32  `db:"assetstreams_id" json:"assetstreamsId"`
+	ID             int32  `db:"id" json:"id"`
+	LanguagesCode  string `db:"languages_code" json:"languagesCode"`
 }
 
 type AssetstreamsSubtitleLanguage struct {
-	AssetstreamsID null_v4.Int    `db:"assetstreams_id" json:"assetstreamsId"`
-	ID             int32          `db:"id" json:"id"`
-	LanguagesCode  null_v4.String `db:"languages_code" json:"languagesCode"`
+	AssetstreamsID int32  `db:"assetstreams_id" json:"assetstreamsId"`
+	ID             int32  `db:"id" json:"id"`
+	LanguagesCode  string `db:"languages_code" json:"languagesCode"`
 }
 
 type CalendarentriesTranslation struct {
-	CalendarentriesID null_v4.Int    `db:"calendarentries_id" json:"calendarentriesId"`
+	CalendarentriesID int32          `db:"calendarentries_id" json:"calendarentriesId"`
 	Description       null_v4.String `db:"description" json:"description"`
 	ID                int32          `db:"id" json:"id"`
 	LanguagesCode     string         `db:"languages_code" json:"languagesCode"`
@@ -216,25 +216,6 @@ type Calendarentry struct {
 	Label         null_v4.String `db:"label" json:"label"`
 }
 
-type CategoriesTranslation struct {
-	CategoriesID  int32  `db:"categories_id" json:"categoriesId"`
-	ID            int32  `db:"id" json:"id"`
-	LanguagesCode string `db:"languages_code" json:"languagesCode"`
-	Name          string `db:"name" json:"name"`
-}
-
-type Category struct {
-	AppearInSearch sql.NullBool  `db:"appear_in_search" json:"appearInSearch"`
-	DateCreated    time.Time     `db:"date_created" json:"dateCreated"`
-	DateUpdated    time.Time     `db:"date_updated" json:"dateUpdated"`
-	ID             int32         `db:"id" json:"id"`
-	LegacyID       null_v4.Int   `db:"legacy_id" json:"legacyId"`
-	ParentID       null_v4.Int   `db:"parent_id" json:"parentId"`
-	Sort           null_v4.Int   `db:"sort" json:"sort"`
-	UserCreated    uuid.NullUUID `db:"user_created" json:"userCreated"`
-	UserUpdated    uuid.NullUUID `db:"user_updated" json:"userUpdated"`
-}
-
 type Collection struct {
 	DateCreated    time.Time             `db:"date_created" json:"dateCreated"`
 	DateUpdated    time.Time             `db:"date_updated" json:"dateUpdated"`
@@ -250,33 +231,17 @@ type Collection struct {
 }
 
 type CollectionsEntry struct {
-	ID            int32          `db:"id" json:"id"`
-	CollectionsID int32          `db:"collections_id" json:"collectionsId"`
-	Item          null_v4.String `db:"item" json:"item"`
-	Collection    null_v4.String `db:"collection" json:"collection"`
-	Sort          null_v4.Int    `db:"sort" json:"sort"`
-}
-
-type CollectionsItem struct {
-	CollectionID null_v4.Int    `db:"collection_id" json:"collectionId"`
-	DateCreated  null_v4.Time   `db:"date_created" json:"dateCreated"`
-	DateUpdated  null_v4.Time   `db:"date_updated" json:"dateUpdated"`
-	EpisodeID    null_v4.Int    `db:"episode_id" json:"episodeId"`
-	ID           int32          `db:"id" json:"id"`
-	PageID       null_v4.Int    `db:"page_id" json:"pageId"`
-	SeasonID     null_v4.Int    `db:"season_id" json:"seasonId"`
-	ShowID       null_v4.Int    `db:"show_id" json:"showId"`
-	Sort         null_v4.Int    `db:"sort" json:"sort"`
-	Type         null_v4.String `db:"type" json:"type"`
-	UserCreated  uuid.NullUUID  `db:"user_created" json:"userCreated"`
-	UserUpdated  uuid.NullUUID  `db:"user_updated" json:"userUpdated"`
-	LinkID       null_v4.Int    `db:"link_id" json:"linkId"`
+	ID            int32       `db:"id" json:"id"`
+	CollectionsID int32       `db:"collections_id" json:"collectionsId"`
+	Item          string      `db:"item" json:"item"`
+	Collection    string      `db:"collection" json:"collection"`
+	Sort          null_v4.Int `db:"sort" json:"sort"`
 }
 
 type CollectionsTranslation struct {
 	ID            int32          `db:"id" json:"id"`
-	CollectionsID null_v4.Int    `db:"collections_id" json:"collectionsId"`
-	LanguagesCode null_v4.String `db:"languages_code" json:"languagesCode"`
+	CollectionsID int32          `db:"collections_id" json:"collectionsId"`
+	LanguagesCode string         `db:"languages_code" json:"languagesCode"`
 	Slug          null_v4.String `db:"slug" json:"slug"`
 	Title         null_v4.String `db:"title" json:"title"`
 }
@@ -707,12 +672,6 @@ type EpisodeRole struct {
 	RolesEarlyaccess interface{} `db:"roles_earlyaccess" json:"rolesEarlyaccess"`
 }
 
-type EpisodesCategory struct {
-	CategoriesID int32 `db:"categories_id" json:"categoriesId"`
-	EpisodesID   int32 `db:"episodes_id" json:"episodesId"`
-	ID           int32 `db:"id" json:"id"`
-}
-
 type EpisodesTag struct {
 	EpisodesID int32 `db:"episodes_id" json:"episodesId"`
 	ID         int32 `db:"id" json:"id"`
@@ -767,9 +726,9 @@ type Event struct {
 
 type EventsTranslation struct {
 	Description   null_v4.String `db:"description" json:"description"`
-	EventsID      null_v4.Int    `db:"events_id" json:"eventsId"`
+	EventsID      int32          `db:"events_id" json:"eventsId"`
 	ID            int32          `db:"id" json:"id"`
-	LanguagesCode null_v4.String `db:"languages_code" json:"languagesCode"`
+	LanguagesCode string         `db:"languages_code" json:"languagesCode"`
 	Title         null_v4.String `db:"title" json:"title"`
 }
 
@@ -816,9 +775,9 @@ type FaqsTranslation struct {
 }
 
 type FaqsUsergroup struct {
-	ID             int32          `db:"id" json:"id"`
-	FaqsID         uuid.NullUUID  `db:"faqs_id" json:"faqsId"`
-	UsergroupsCode null_v4.String `db:"usergroups_code" json:"usergroupsCode"`
+	ID             int32     `db:"id" json:"id"`
+	FaqsID         uuid.UUID `db:"faqs_id" json:"faqsId"`
+	UsergroupsCode string    `db:"usergroups_code" json:"usergroupsCode"`
 }
 
 type FilterDataset struct {
@@ -852,9 +811,9 @@ type Game struct {
 }
 
 type GamesStyledimage struct {
-	ID             int32         `db:"id" json:"id"`
-	GamesID        uuid.NullUUID `db:"games_id" json:"gamesId"`
-	StyledimagesID uuid.NullUUID `db:"styledimages_id" json:"styledimagesId"`
+	ID             int32     `db:"id" json:"id"`
+	GamesID        uuid.UUID `db:"games_id" json:"gamesId"`
+	StyledimagesID uuid.UUID `db:"styledimages_id" json:"styledimagesId"`
 }
 
 type GamesTranslation struct {
@@ -925,19 +884,19 @@ type Lesson struct {
 }
 
 type LessonsImage struct {
-	ID       uuid.UUID     `db:"id" json:"id"`
-	LessonID uuid.NullUUID `db:"lesson_id" json:"lessonId"`
-	File     uuid.UUID     `db:"file" json:"file"`
-	Language string        `db:"language" json:"language"`
-	Style    string        `db:"style" json:"style"`
+	ID       uuid.UUID `db:"id" json:"id"`
+	LessonID uuid.UUID `db:"lesson_id" json:"lessonId"`
+	File     uuid.UUID `db:"file" json:"file"`
+	Language string    `db:"language" json:"language"`
+	Style    string    `db:"style" json:"style"`
 }
 
 type LessonsRelation struct {
-	ID         int32          `db:"id" json:"id"`
-	LessonsID  uuid.NullUUID  `db:"lessons_id" json:"lessonsId"`
-	Item       null_v4.String `db:"item" json:"item"`
-	Sort       null_v4.Int    `db:"sort" json:"sort"`
-	Collection null_v4.String `db:"collection" json:"collection"`
+	ID         int32       `db:"id" json:"id"`
+	LessonsID  uuid.UUID   `db:"lessons_id" json:"lessonsId"`
+	Item       string      `db:"item" json:"item"`
+	Sort       null_v4.Int `db:"sort" json:"sort"`
+	Collection string      `db:"collection" json:"collection"`
 }
 
 type LessonsTranslation struct {
@@ -971,25 +930,6 @@ type LinksTranslation struct {
 	Description   string `db:"description" json:"description"`
 }
 
-type List struct {
-	DateCreated      time.Time     `db:"date_created" json:"dateCreated"`
-	DateUpdated      time.Time     `db:"date_updated" json:"dateUpdated"`
-	ID               int32         `db:"id" json:"id"`
-	LegacyCategoryID null_v4.Int   `db:"legacy_category_id" json:"legacyCategoryId"`
-	LegacyNameID     null_v4.Int   `db:"legacy_name_id" json:"legacyNameId"`
-	Name             string        `db:"name" json:"name"`
-	UserCreated      uuid.NullUUID `db:"user_created" json:"userCreated"`
-	UserUpdated      uuid.NullUUID `db:"user_updated" json:"userUpdated"`
-}
-
-type ListsRelation struct {
-	Collection null_v4.String `db:"collection" json:"collection"`
-	ID         int32          `db:"id" json:"id"`
-	Item       null_v4.String `db:"item" json:"item"`
-	ListsID    null_v4.Int    `db:"lists_id" json:"listsId"`
-	Sort       null_v4.Int    `db:"sort" json:"sort"`
-}
-
 type MaterializedViewsMetum struct {
 	ViewName      string       `db:"view_name" json:"viewName"`
 	LastRefreshed null_v4.Time `db:"last_refreshed" json:"lastRefreshed"`
@@ -1007,9 +947,9 @@ type Message struct {
 }
 
 type MessagesMessagetemplate struct {
-	ID                 int32       `db:"id" json:"id"`
-	MessagesID         null_v4.Int `db:"messages_id" json:"messagesId"`
-	MessagetemplatesID null_v4.Int `db:"messagetemplates_id" json:"messagetemplatesId"`
+	ID                 int32 `db:"id" json:"id"`
+	MessagesID         int32 `db:"messages_id" json:"messagesId"`
+	MessagetemplatesID int32 `db:"messagetemplates_id" json:"messagetemplatesId"`
 }
 
 type Messagetemplate struct {
@@ -1027,7 +967,7 @@ type MessagetemplatesTranslation struct {
 	ID                 int32          `db:"id" json:"id"`
 	LanguagesCode      string         `db:"languages_code" json:"languagesCode"`
 	Message            string         `db:"message" json:"message"`
-	MessagetemplatesID null_v4.Int    `db:"messagetemplates_id" json:"messagetemplatesId"`
+	MessagetemplatesID int32          `db:"messagetemplates_id" json:"messagetemplatesId"`
 }
 
 type Notification struct {
@@ -1047,9 +987,9 @@ type Notification struct {
 }
 
 type NotificationsTarget struct {
-	ID              int32         `db:"id" json:"id"`
-	NotificationsID uuid.NullUUID `db:"notifications_id" json:"notificationsId"`
-	TargetsID       uuid.NullUUID `db:"targets_id" json:"targetsId"`
+	ID              int32     `db:"id" json:"id"`
+	NotificationsID uuid.UUID `db:"notifications_id" json:"notificationsId"`
+	TargetsID       uuid.UUID `db:"targets_id" json:"targetsId"`
 }
 
 type Notificationtemplate struct {
@@ -1064,7 +1004,7 @@ type Notificationtemplate struct {
 
 type NotificationtemplatesTranslation struct {
 	ID                      int32          `db:"id" json:"id"`
-	NotificationtemplatesID uuid.NullUUID  `db:"notificationtemplates_id" json:"notificationtemplatesId"`
+	NotificationtemplatesID uuid.UUID      `db:"notificationtemplates_id" json:"notificationtemplatesId"`
 	LanguagesCode           string         `db:"languages_code" json:"languagesCode"`
 	Title                   null_v4.String `db:"title" json:"title"`
 	Description             null_v4.String `db:"description" json:"description"`
@@ -1107,8 +1047,8 @@ type Phrase struct {
 
 type PhrasesTranslation struct {
 	ID            int32          `db:"id" json:"id"`
-	PhrasesKey    null_v4.String `db:"phrases_key" json:"phrasesKey"`
-	LanguagesCode null_v4.String `db:"languages_code" json:"languagesCode"`
+	PhrasesKey    string         `db:"phrases_key" json:"phrasesKey"`
+	LanguagesCode string         `db:"languages_code" json:"languagesCode"`
 	Value         null_v4.String `db:"value" json:"value"`
 }
 
@@ -1161,14 +1101,14 @@ type Prompt struct {
 }
 
 type PromptsTarget struct {
-	ID        int32         `db:"id" json:"id"`
-	PromptsID uuid.NullUUID `db:"prompts_id" json:"promptsId"`
-	TargetsID uuid.NullUUID `db:"targets_id" json:"targetsId"`
+	ID        int32     `db:"id" json:"id"`
+	PromptsID uuid.UUID `db:"prompts_id" json:"promptsId"`
+	TargetsID uuid.UUID `db:"targets_id" json:"targetsId"`
 }
 
 type PromptsTranslation struct {
 	ID             int32          `db:"id" json:"id"`
-	PromptsID      uuid.NullUUID  `db:"prompts_id" json:"promptsId"`
+	PromptsID      uuid.UUID      `db:"prompts_id" json:"promptsId"`
 	LanguagesCode  string         `db:"languages_code" json:"languagesCode"`
 	Title          null_v4.String `db:"title" json:"title"`
 	SecondaryTitle null_v4.String `db:"secondary_title" json:"secondaryTitle"`
@@ -1342,9 +1282,9 @@ type ShowRole struct {
 }
 
 type ShowsTag struct {
-	ID      int32       `db:"id" json:"id"`
-	ShowsID null_v4.Int `db:"shows_id" json:"showsId"`
-	TagsID  null_v4.Int `db:"tags_id" json:"tagsId"`
+	ID      int32 `db:"id" json:"id"`
+	ShowsID int32 `db:"shows_id" json:"showsId"`
+	TagsID  int32 `db:"tags_id" json:"tagsId"`
 }
 
 type ShowsTranslation struct {
@@ -1381,8 +1321,8 @@ type Songcollection struct {
 
 type SongcollectionsTranslation struct {
 	ID                int32          `db:"id" json:"id"`
-	SongcollectionsID uuid.NullUUID  `db:"songcollections_id" json:"songcollectionsId"`
-	LanguagesCode     null_v4.String `db:"languages_code" json:"languagesCode"`
+	SongcollectionsID uuid.UUID      `db:"songcollections_id" json:"songcollectionsId"`
+	LanguagesCode     string         `db:"languages_code" json:"languagesCode"`
 	Title             null_v4.String `db:"title" json:"title"`
 }
 
@@ -1507,7 +1447,7 @@ type TagsTranslation struct {
 	ID            int32          `db:"id" json:"id"`
 	LanguagesCode string         `db:"languages_code" json:"languagesCode"`
 	Name          null_v4.String `db:"name" json:"name"`
-	TagsID        null_v4.Int    `db:"tags_id" json:"tagsId"`
+	TagsID        int32          `db:"tags_id" json:"tagsId"`
 }
 
 type Target struct {
@@ -1517,9 +1457,9 @@ type Target struct {
 }
 
 type TargetsUsergroup struct {
-	ID             int32          `db:"id" json:"id"`
-	TargetsID      uuid.NullUUID  `db:"targets_id" json:"targetsId"`
-	UsergroupsCode null_v4.String `db:"usergroups_code" json:"usergroupsCode"`
+	ID             int32     `db:"id" json:"id"`
+	TargetsID      uuid.UUID `db:"targets_id" json:"targetsId"`
+	UsergroupsCode string    `db:"usergroups_code" json:"usergroupsCode"`
 }
 
 type Task struct {
@@ -1568,7 +1508,7 @@ type TimedmetadataPerson struct {
 
 type TimedmetadataTranslation struct {
 	ID              int32          `db:"id" json:"id"`
-	TimedmetadataID uuid.NullUUID  `db:"timedmetadata_id" json:"timedmetadataId"`
+	TimedmetadataID uuid.UUID      `db:"timedmetadata_id" json:"timedmetadataId"`
 	LanguagesCode   string         `db:"languages_code" json:"languagesCode"`
 	Title           null_v4.String `db:"title" json:"title"`
 	Description     null_v4.String `db:"description" json:"description"`

--- a/backend/sqlc/studies.sql.go
+++ b/backend/sqlc/studies.sql.go
@@ -463,8 +463,8 @@ type getEpisodesForLessonsParams struct {
 }
 
 type getEpisodesForLessonsRow struct {
-	ID       null_v4.String `db:"id" json:"id"`
-	ParentID uuid.NullUUID  `db:"parent_id" json:"parentId"`
+	ID       string    `db:"id" json:"id"`
+	ParentID uuid.UUID `db:"parent_id" json:"parentId"`
 }
 
 func (q *Queries) getEpisodesForLessons(ctx context.Context, arg getEpisodesForLessonsParams) ([]getEpisodesForLessonsRow, error) {
@@ -566,13 +566,13 @@ ORDER BY rl.sort
 `
 
 type getLessonsForItemsInCollectionParams struct {
-	Collection null_v4.String `db:"collection" json:"collection"`
-	Column2    []string       `db:"column_2" json:"column2"`
+	Collection string   `db:"collection" json:"collection"`
+	Column2    []string `db:"column_2" json:"column2"`
 }
 
 type getLessonsForItemsInCollectionRow struct {
-	ID       uuid.NullUUID  `db:"id" json:"id"`
-	ParentID null_v4.String `db:"parent_id" json:"parentId"`
+	ID       uuid.UUID `db:"id" json:"id"`
+	ParentID string    `db:"parent_id" json:"parentId"`
 }
 
 func (q *Queries) getLessonsForItemsInCollection(ctx context.Context, arg getLessonsForItemsInCollectionParams) ([]getLessonsForItemsInCollectionRow, error) {
@@ -644,8 +644,8 @@ ORDER BY rl.sort
 `
 
 type getLinksForLessonsRow struct {
-	ID       null_v4.String `db:"id" json:"id"`
-	ParentID uuid.NullUUID  `db:"parent_id" json:"parentId"`
+	ID       string    `db:"id" json:"id"`
+	ParentID uuid.UUID `db:"parent_id" json:"parentId"`
 }
 
 func (q *Queries) getLinksForLessons(ctx context.Context, dollar_1 []uuid.UUID) ([]getLinksForLessonsRow, error) {

--- a/backend/sqlc/study-queries.go
+++ b/backend/sqlc/study-queries.go
@@ -203,7 +203,7 @@ func (rq *RoleQueries) GetLessonIDsWithRoles(ctx context.Context, ids []uuid.UUI
 // GetLessonIDsForEpisodes returns lessons for episodes
 func (rq *RoleQueries) GetLessonIDsForEpisodes(ctx context.Context, ids []int) ([]loaders.Relation[uuid.UUID, int], error) {
 	rows, err := rq.queries.getLessonsForItemsInCollection(ctx, getLessonsForItemsInCollectionParams{
-		Collection: null.StringFrom("episodes"),
+		Collection: "episodes",
 		Column2: lo.Map(ids, func(i int, _ int) string {
 			return strconv.Itoa(i)
 		}),
@@ -212,9 +212,9 @@ func (rq *RoleQueries) GetLessonIDsForEpisodes(ctx context.Context, ids []int) (
 		return nil, err
 	}
 	return lo.Map(rows, func(i getLessonsForItemsInCollectionRow, _ int) loaders.Relation[uuid.UUID, int] {
-		p, _ := strconv.ParseInt(i.ParentID.String, 10, 64)
+		p, _ := strconv.ParseInt(i.ParentID, 10, 64)
 		return relation[uuid.UUID, int]{
-			ID:       i.ID.UUID,
+			ID:       i.ID,
 			ParentID: int(p),
 		}
 	}), nil
@@ -223,7 +223,7 @@ func (rq *RoleQueries) GetLessonIDsForEpisodes(ctx context.Context, ids []int) (
 // GetLessonIDsForLinks returns lessons for episodes
 func (rq *RoleQueries) GetLessonIDsForLinks(ctx context.Context, ids []int) ([]loaders.Relation[uuid.UUID, int], error) {
 	rows, err := rq.queries.getLessonsForItemsInCollection(ctx, getLessonsForItemsInCollectionParams{
-		Collection: null.StringFrom("links"),
+		Collection: "links",
 		Column2: lo.Map(ids, func(i int, _ int) string {
 			return strconv.Itoa(i)
 		}),
@@ -232,9 +232,9 @@ func (rq *RoleQueries) GetLessonIDsForLinks(ctx context.Context, ids []int) ([]l
 		return nil, err
 	}
 	return lo.Map(rows, func(i getLessonsForItemsInCollectionRow, _ int) loaders.Relation[uuid.UUID, int] {
-		p, _ := strconv.ParseInt(i.ParentID.String, 10, 64)
+		p, _ := strconv.ParseInt(i.ParentID, 10, 64)
 		return relation[uuid.UUID, int]{
-			ID:       i.ID.UUID,
+			ID:       i.ID,
 			ParentID: int(p),
 		}
 	}), nil
@@ -250,10 +250,10 @@ func (rq *RoleQueries) GetEpisodeIDsForLessons(ctx context.Context, ids []uuid.U
 		return nil, err
 	}
 	return lo.Map(rows, func(i getEpisodesForLessonsRow, _ int) loaders.Relation[int, uuid.UUID] {
-		p, _ := strconv.ParseInt(i.ID.String, 10, 64)
+		p, _ := strconv.ParseInt(i.ID, 10, 64)
 		return relation[int, uuid.UUID]{
 			ID:       int(p),
-			ParentID: i.ParentID.UUID,
+			ParentID: i.ParentID,
 		}
 	}), nil
 }
@@ -265,10 +265,10 @@ func (rq *RoleQueries) GetLinkIDsForLessons(ctx context.Context, ids []uuid.UUID
 		return nil, err
 	}
 	return lo.Map(rows, func(i getLinksForLessonsRow, _ int) loaders.Relation[int, uuid.UUID] {
-		p, _ := strconv.ParseInt(i.ID.String, 10, 64)
+		p, _ := strconv.ParseInt(i.ID, 10, 64)
 		return relation[int, uuid.UUID]{
 			ID:       int(p),
-			ParentID: i.ParentID.UUID,
+			ParentID: i.ParentID,
 		}
 	}), nil
 }

--- a/migrations/00235_remove_unused_tables.sql
+++ b/migrations/00235_remove_unused_tables.sql
@@ -1,0 +1,1312 @@
+-- +goose Up
+/***********************************************************/
+/*** SCRIPT AUTHOR: Fredrik Vedvik (fredrik@vedvik.tech) ***/
+/***    CREATED ON: 2023-11-07T13:43:21.837Z             ***/
+/***********************************************************/
+
+--- BEGIN ALTER TABLE "public"."lessons" ---
+
+ALTER TABLE IF EXISTS "public"."lessons"
+    ALTER COLUMN "translations_required" DROP DEFAULT;
+
+--- END ALTER TABLE "public"."lessons" ---
+
+--- BEGIN ALTER TABLE "public"."episodes_categories" ---
+
+ALTER TABLE IF EXISTS "public"."episodes_categories"
+    DROP COLUMN IF EXISTS "categories_id" CASCADE; --WARN: Drop column can occure in data loss!
+
+ALTER TABLE IF EXISTS "public"."episodes_categories"
+    DROP CONSTRAINT IF EXISTS "episodes_categories_categories_id_foreign";
+
+--- END ALTER TABLE "public"."episodes_categories" ---
+
+--- BEGIN ALTER TABLE "public"."lists_relations" ---
+
+ALTER TABLE IF EXISTS "public"."lists_relations"
+    DROP COLUMN IF EXISTS "lists_id" CASCADE; --WARN: Drop column can occure in data loss!
+
+ALTER TABLE IF EXISTS "public"."lists_relations"
+    DROP CONSTRAINT IF EXISTS "lists_relations_lists_id_foreign";
+
+--- END ALTER TABLE "public"."lists_relations" ---
+
+--- BEGIN ALTER TABLE "public"."categories_translations" ---
+
+ALTER TABLE IF EXISTS "public"."categories_translations"
+    DROP COLUMN IF EXISTS "categories_id" CASCADE; --WARN: Drop column can occure in data loss!
+
+ALTER TABLE IF EXISTS "public"."categories_translations"
+    DROP CONSTRAINT IF EXISTS "categories_translations_categories_id_foreign";
+
+--- END ALTER TABLE "public"."categories_translations" ---
+
+--- BEGIN DROP TABLE "public"."categories" ---
+
+DROP TABLE IF EXISTS "public"."categories";
+
+--- END DROP TABLE "public"."categories" ---
+
+--- BEGIN DROP TABLE "public"."lists" ---
+
+DROP TABLE IF EXISTS "public"."lists";
+
+--- END DROP TABLE "public"."lists" ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+UPDATE "public"."directus_fields"
+SET "width" = 'full'
+WHERE "id" = 1351;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 2
+WHERE "id" = 1353;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 3
+WHERE "id" = 1354;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 4
+WHERE "id" = 1355;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 5
+WHERE "id" = 1356;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 2
+WHERE "id" = 1382;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 6
+WHERE "id" = 1352;
+
+UPDATE "public"."directus_fields"
+SET "sort"  = 1,
+    "group" = 'configuration'
+WHERE "id" = 1191;
+
+UPDATE "public"."directus_fields"
+SET "hidden" = false
+WHERE "id" = 884;
+
+UPDATE "public"."directus_fields"
+SET "required" = true
+WHERE "id" = 1077;
+
+UPDATE "public"."directus_fields"
+SET "hidden" = true
+WHERE "id" = 1067;
+
+UPDATE "public"."directus_fields"
+SET "required" = true
+WHERE "id" = 1062;
+
+UPDATE "public"."directus_fields"
+SET "hidden" = true
+WHERE "id" = 1065;
+
+UPDATE "public"."directus_fields"
+SET "width" = 'full'
+WHERE "id" = 1049;
+
+UPDATE "public"."directus_fields"
+SET "interface" = 'input'
+WHERE "id" = 1221;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 2
+WHERE "id" = 1192;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 3
+WHERE "id" = 1200;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 3
+WHERE "id" = 1193;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 4
+WHERE "id" = 1194;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 4
+WHERE "id" = 1201;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 5
+WHERE "id" = 1206;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 5
+WHERE "id" = 1195;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 6
+WHERE "id" = 1207;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 6
+WHERE "id" = 1217;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 7
+WHERE "id" = 1196;
+
+UPDATE "public"."directus_fields"
+SET "width" = 'full'
+WHERE "id" = 1190;
+
+UPDATE "public"."directus_fields"
+SET "hidden" = false,
+    "sort"   = 8
+WHERE "id" = 1202;
+
+UPDATE "public"."directus_fields"
+SET "interface" = 'input'
+WHERE "id" = 1222;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 69;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 179;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 180;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 72;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 73;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 74;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 75;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 76;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 77;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 78;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 79;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 80;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 81;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 150;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 181;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 182;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 184;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 185;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 189;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 71;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 178;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 70;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 183;
+
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 177;
+
+--- END SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+UPDATE "public"."directus_collections"
+SET "sort" = 2
+WHERE "collection" = 'main_content';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 4
+WHERE "collection" = 'page_management';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 5
+WHERE "collection" = 'calendar';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 6
+WHERE "collection" = 'asset_management';
+
+INSERT INTO "public"."directus_collections" ("collection", "icon", "note", "display_template", "hidden", "singleton",
+                                             "translations", "archive_field", "archive_app_filter", "archive_value",
+                                             "unarchive_value", "sort_field", "accountability", "color",
+                                             "item_duplication_fields", "sort", "group", "collapse", "preview_url",
+                                             "versioning")
+VALUES ('Metadata', 'folder', NULL, NULL, false, false, NULL, NULL, true, NULL, NULL, NULL, 'all', NULL, NULL, 9, NULL,
+        'open', NULL, false);
+
+UPDATE "public"."directus_collections"
+SET "sort" = 14
+WHERE "collection" = 'config';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 22
+WHERE "collection" = 'playlists_styledimages';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 25
+WHERE "collection" = 'playlists_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 26
+WHERE "collection" = 'playlists_usergroups';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 3
+WHERE "collection" = 'studies';
+
+UPDATE "public"."directus_collections"
+SET "group" = NULL
+WHERE "collection" = 'lists_relations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 8
+WHERE "collection" = 'computeddata_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 10
+WHERE "collection" = 'notifications_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 11
+WHERE "collection" = 'faqs_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 13
+WHERE "collection" = 'applications_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 19
+WHERE "collection" = 'translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 20
+WHERE "collection" = 'songcollections_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 21
+WHERE "collection" = 'phrases_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 23
+WHERE "collection" = 'songs_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 24
+WHERE "collection" = 'timedmetadata_persons';
+
+UPDATE "public"."directus_collections"
+SET "sort"  = 1,
+    "group" = 'Metadata'
+WHERE "collection" = 'persons';
+
+UPDATE "public"."directus_collections"
+SET "sort"  = 2,
+    "group" = 'Metadata'
+WHERE "collection" = 'songs_group';
+
+UPDATE "public"."directus_collections"
+SET "sort"  = 3,
+    "group" = 'Metadata'
+WHERE "collection" = 'phrases';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 7
+WHERE "collection" = 'achievements_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 12
+WHERE "collection" = 'messages_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 15
+WHERE "collection" = 'timedmetadata';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 16
+WHERE "collection" = 'materialized_views_meta';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 17
+WHERE "collection" = 'images';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 18
+WHERE "collection" = 'styledimages';
+
+DELETE
+FROM "public"."directus_collections"
+WHERE "collection" = 'lists';
+
+DELETE
+FROM "public"."directus_collections"
+WHERE "collection" = 'categories';
+
+--- END SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_permissions" RECORDS ---
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 120;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 202;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 123;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 203;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 204;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 122;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 121;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 201;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 124;
+
+DELETE
+FROM "public"."directus_permissions"
+WHERE "id" = 200;
+
+--- END SYNCHRONIZE TABLE "public"."directus_permissions" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 19;
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 20;
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 21;
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 22;
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 44;
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 56;
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 57;
+
+DELETE
+FROM "public"."directus_relations"
+WHERE "id" = 59;
+
+--- END SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
+
+--- BEGIN DROP TABLE "public"."lists_relations" ---
+
+DROP TABLE IF EXISTS "public"."lists_relations";
+
+--- END DROP TABLE "public"."lists_relations" ---
+
+--- BEGIN DROP TABLE "public"."categories_translations" ---
+
+DROP TABLE IF EXISTS "public"."categories_translations";
+
+--- END DROP TABLE "public"."categories_translations" ---
+
+--- BEGIN DROP TABLE "public"."episodes_categories" ---
+
+DROP TABLE IF EXISTS "public"."episodes_categories";
+
+--- END DROP TABLE "public"."episodes_categories" ---
+-- +goose Down
+/***********************************************************/
+/*** SCRIPT AUTHOR: Fredrik Vedvik (fredrik@vedvik.tech) ***/
+/***    CREATED ON: 2023-11-07T13:43:23.595Z             ***/
+/***********************************************************/
+
+
+--- BEGIN CREATE TABLE "public"."episodes_categories" ---
+
+CREATE TABLE IF NOT EXISTS "public"."episodes_categories"
+(
+    "episodes_id" int4 NOT NULL,
+    "id"          int4 NOT NULL DEFAULT nextval('episodes_categories_id_seq'::regclass),
+    CONSTRAINT "episodes_categories_episodes_id_foreign" FOREIGN KEY (episodes_id) REFERENCES episodes (id) ON DELETE CASCADE,
+    CONSTRAINT "episodes_categories_pkey" PRIMARY KEY (id)
+);
+
+GRANT SELECT ON TABLE "public"."episodes_categories" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT INSERT ON TABLE "public"."episodes_categories" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT UPDATE ON TABLE "public"."episodes_categories" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT DELETE ON TABLE "public"."episodes_categories" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRUNCATE ON TABLE "public"."episodes_categories" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT REFERENCES ON TABLE "public"."episodes_categories" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRIGGER ON TABLE "public"."episodes_categories" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT SELECT ON TABLE "public"."episodes_categories" TO api; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+
+COMMENT ON COLUMN "public"."episodes_categories"."episodes_id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."episodes_categories"."id" IS NULL;
+
+COMMENT ON CONSTRAINT "episodes_categories_episodes_id_foreign" ON "public"."episodes_categories" IS NULL;
+
+
+COMMENT ON CONSTRAINT "episodes_categories_pkey" ON "public"."episodes_categories" IS NULL;
+
+COMMENT ON TABLE "public"."episodes_categories" IS NULL;
+
+--- END CREATE TABLE "public"."episodes_categories" ---
+
+
+--- BEGIN CREATE TABLE "public"."lists_relations" ---
+
+CREATE TABLE IF NOT EXISTS "public"."lists_relations"
+(
+    "collection" varchar(255) NULL     DEFAULT NULL::character varying,
+    "id"         int4         NOT NULL DEFAULT nextval('lists_relations_id_seq'::regclass),
+    "item"       varchar(255) NULL     DEFAULT NULL::character varying,
+    "sort"       int4         NULL,
+    CONSTRAINT "lists_relations_pkey" PRIMARY KEY (id)
+);
+
+GRANT SELECT ON TABLE "public"."lists_relations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT INSERT ON TABLE "public"."lists_relations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT UPDATE ON TABLE "public"."lists_relations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT DELETE ON TABLE "public"."lists_relations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRUNCATE ON TABLE "public"."lists_relations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT REFERENCES ON TABLE "public"."lists_relations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRIGGER ON TABLE "public"."lists_relations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT SELECT ON TABLE "public"."lists_relations" TO api; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+
+COMMENT ON COLUMN "public"."lists_relations"."collection" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists_relations"."id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists_relations"."item" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists_relations"."sort" IS NULL;
+
+COMMENT ON CONSTRAINT "lists_relations_pkey" ON "public"."lists_relations" IS NULL;
+
+COMMENT ON TABLE "public"."lists_relations" IS NULL;
+
+--- END CREATE TABLE "public"."lists_relations" ---
+
+--- BEGIN CREATE TABLE "public"."categories_translations" ---
+
+CREATE TABLE IF NOT EXISTS "public"."categories_translations"
+(
+    "id"             int4         NOT NULL DEFAULT nextval('categories_translations_id_seq'::regclass),
+    "languages_code" varchar(255) NOT NULL DEFAULT NULL::character varying,
+    "name"           varchar(255) NOT NULL DEFAULT NULL::character varying,
+    CONSTRAINT "categories_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code),
+    CONSTRAINT "categories_translations_pkey" PRIMARY KEY (id)
+);
+
+GRANT SELECT ON TABLE "public"."categories_translations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT INSERT ON TABLE "public"."categories_translations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT UPDATE ON TABLE "public"."categories_translations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT DELETE ON TABLE "public"."categories_translations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRUNCATE ON TABLE "public"."categories_translations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT REFERENCES ON TABLE "public"."categories_translations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRIGGER ON TABLE "public"."categories_translations" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT SELECT ON TABLE "public"."categories_translations" TO api; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+
+COMMENT ON COLUMN "public"."categories_translations"."id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories_translations"."languages_code" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories_translations"."name" IS NULL;
+
+COMMENT ON CONSTRAINT "categories_translations_languages_code_foreign" ON "public"."categories_translations" IS NULL;
+
+
+COMMENT ON CONSTRAINT "categories_translations_pkey" ON "public"."categories_translations" IS NULL;
+
+COMMENT ON TABLE "public"."categories_translations" IS NULL;
+
+--- END CREATE TABLE "public"."categories_translations" ---
+
+
+--- BEGIN ALTER TABLE "public"."lessons" ---
+
+ALTER TABLE IF EXISTS "public"."lessons"
+    ALTER COLUMN "translations_required" SET DEFAULT true;
+
+--- END ALTER TABLE "public"."lessons" ---
+
+--- BEGIN CREATE TABLE "public"."categories" ---
+
+CREATE TABLE IF NOT EXISTS "public"."categories"
+(
+    "appear_in_search" bool        NULL     DEFAULT false,
+    "date_created"     timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "date_updated"     timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "id"               int4        NOT NULL DEFAULT nextval('categories_id_seq'::regclass),
+    "legacy_id"        int4        NULL,
+    "parent_id"        int4        NULL,
+    "sort"             int4        NULL,
+    "user_created"     uuid        NULL,
+    "user_updated"     uuid        NULL,
+    CONSTRAINT "categories_parent_id_foreign" FOREIGN KEY (parent_id) REFERENCES categories (id),
+    CONSTRAINT "categories_pkey" PRIMARY KEY (id),
+    CONSTRAINT "categories_user_created_foreign" FOREIGN KEY (user_created) REFERENCES directus_users (id),
+    CONSTRAINT "categories_user_updated_foreign" FOREIGN KEY (user_updated) REFERENCES directus_users (id)
+);
+
+ALTER TABLE IF EXISTS "public"."categories"
+    OWNER TO manager;
+
+GRANT SELECT ON TABLE "public"."categories" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT INSERT ON TABLE "public"."categories" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT UPDATE ON TABLE "public"."categories" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT DELETE ON TABLE "public"."categories" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRUNCATE ON TABLE "public"."categories" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT REFERENCES ON TABLE "public"."categories" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRIGGER ON TABLE "public"."categories" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT SELECT ON TABLE "public"."categories" TO api; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+
+COMMENT ON COLUMN "public"."categories"."appear_in_search" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."date_created" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."date_updated" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."legacy_id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."parent_id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."sort" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."user_created" IS NULL;
+
+
+COMMENT ON COLUMN "public"."categories"."user_updated" IS NULL;
+
+COMMENT ON CONSTRAINT "categories_parent_id_foreign" ON "public"."categories" IS NULL;
+
+
+COMMENT ON CONSTRAINT "categories_pkey" ON "public"."categories" IS NULL;
+
+
+COMMENT ON CONSTRAINT "categories_user_created_foreign" ON "public"."categories" IS NULL;
+
+
+COMMENT ON CONSTRAINT "categories_user_updated_foreign" ON "public"."categories" IS NULL;
+
+COMMENT ON TABLE "public"."categories" IS NULL;
+
+--- END CREATE TABLE "public"."categories" ---
+
+--- BEGIN ALTER TABLE "public"."episodes_categories" ---
+
+ALTER TABLE IF EXISTS "public"."episodes_categories"
+    ADD COLUMN IF NOT EXISTS "categories_id" int4 NOT NULL; --WARN: Add a new column not nullable without a default value can occure in a sql error during execution!
+
+COMMENT ON COLUMN "public"."episodes_categories"."categories_id" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."episodes_categories"
+    ADD CONSTRAINT "episodes_categories_categories_id_foreign" FOREIGN KEY (categories_id) REFERENCES categories (id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "episodes_categories_categories_id_foreign" ON "public"."episodes_categories" IS NULL;
+
+--- END ALTER TABLE "public"."episodes_categories" ---
+
+--- BEGIN CREATE TABLE "public"."lists" ---
+
+CREATE TABLE IF NOT EXISTS "public"."lists"
+(
+    "date_created"       timestamptz  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "date_updated"       timestamptz  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "id"                 int4         NOT NULL DEFAULT nextval('lists_id_seq'::regclass),
+    "legacy_category_id" int4         NULL,
+    "legacy_name_id"     int4         NULL,
+    "name"               varchar(255) NOT NULL DEFAULT NULL::character varying,
+    "user_created"       uuid         NULL,
+    "user_updated"       uuid         NULL,
+    CONSTRAINT "lists_pkey" PRIMARY KEY (id),
+    CONSTRAINT "lists_user_created_foreign" FOREIGN KEY (user_created) REFERENCES directus_users (id),
+    CONSTRAINT "lists_user_updated_foreign" FOREIGN KEY (user_updated) REFERENCES directus_users (id)
+);
+
+ALTER TABLE IF EXISTS "public"."lists"
+    OWNER TO manager;
+
+GRANT SELECT ON TABLE "public"."lists" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT INSERT ON TABLE "public"."lists" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT UPDATE ON TABLE "public"."lists" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT DELETE ON TABLE "public"."lists" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRUNCATE ON TABLE "public"."lists" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT REFERENCES ON TABLE "public"."lists" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRIGGER ON TABLE "public"."lists" TO bccm; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT SELECT ON TABLE "public"."lists" TO api; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+
+COMMENT ON COLUMN "public"."lists"."date_created" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists"."date_updated" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists"."id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists"."legacy_category_id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists"."legacy_name_id" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists"."name" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists"."user_created" IS NULL;
+
+
+COMMENT ON COLUMN "public"."lists"."user_updated" IS NULL;
+
+COMMENT ON CONSTRAINT "lists_pkey" ON "public"."lists" IS NULL;
+
+
+COMMENT ON CONSTRAINT "lists_user_created_foreign" ON "public"."lists" IS NULL;
+
+
+COMMENT ON CONSTRAINT "lists_user_updated_foreign" ON "public"."lists" IS NULL;
+
+COMMENT ON TABLE "public"."lists" IS NULL;
+
+--- END CREATE TABLE "public"."lists" ---
+
+--- BEGIN ALTER TABLE "public"."lists_relations" ---
+
+ALTER TABLE IF EXISTS "public"."lists_relations"
+    ADD COLUMN IF NOT EXISTS "lists_id" int4 NULL;
+
+COMMENT ON COLUMN "public"."lists_relations"."lists_id" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."lists_relations"
+    ADD CONSTRAINT "lists_relations_lists_id_foreign" FOREIGN KEY (lists_id) REFERENCES lists (id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "lists_relations_lists_id_foreign" ON "public"."lists_relations" IS NULL;
+
+--- END ALTER TABLE "public"."lists_relations" ---
+
+--- BEGIN ALTER TABLE "public"."categories_translations" ---
+
+ALTER TABLE IF EXISTS "public"."categories_translations"
+    ADD COLUMN IF NOT EXISTS "categories_id" int4 NOT NULL; --WARN: Add a new column not nullable without a default value can occure in a sql error during execution!
+
+COMMENT ON COLUMN "public"."categories_translations"."categories_id" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."categories_translations"
+    ADD CONSTRAINT "categories_translations_categories_id_foreign" FOREIGN KEY (categories_id) REFERENCES categories (id);
+
+COMMENT ON CONSTRAINT "categories_translations_categories_id_foreign" ON "public"."categories_translations" IS NULL;
+
+--- END ALTER TABLE "public"."categories_translations" ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+UPDATE "public"."directus_collections"
+SET "sort" = 3
+WHERE "collection" = 'page_management';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 4
+WHERE "collection" = 'calendar';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 5
+WHERE "collection" = 'asset_management';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 15
+WHERE "collection" = 'config';
+
+INSERT INTO "public"."directus_collections" ("collection", "icon", "note", "display_template", "hidden", "singleton",
+                                             "translations", "archive_field", "archive_app_filter", "archive_value",
+                                             "unarchive_value", "sort_field", "accountability", "color",
+                                             "item_duplication_fields", "sort", "group", "collapse", "preview_url",
+                                             "versioning")
+VALUES ('lists', 'format_list_numbered', 'Manually selected and ordered shows/episodes.', '{{name}}', true, false, NULL,
+        NULL, true, NULL, NULL, NULL, 'all', NULL, NULL, 5, 'page_management', 'open', NULL, false);
+
+UPDATE "public"."directus_collections"
+SET "sort" = 1
+WHERE "collection" = 'main_content';
+
+INSERT INTO "public"."directus_collections" ("collection", "icon", "note", "display_template", "hidden", "singleton",
+                                             "translations", "archive_field", "archive_app_filter", "archive_value",
+                                             "unarchive_value", "sort_field", "accountability", "color",
+                                             "item_duplication_fields", "sort", "group", "collapse", "preview_url",
+                                             "versioning")
+VALUES ('categories', 'bookmarks', NULL, '{{translations}}', true, false, NULL, NULL, true, NULL, NULL, 'sort', 'all',
+        NULL, NULL, 7, 'page_management', 'open', NULL, false);
+
+UPDATE "public"."directus_collections"
+SET "sort" = 2
+WHERE "collection" = 'studies';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 23
+WHERE "collection" = 'playlists_styledimages';
+
+UPDATE "public"."directus_collections"
+SET "sort" = NULL
+WHERE "collection" = 'playlists_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = NULL
+WHERE "collection" = 'playlists_usergroups';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 7
+WHERE "collection" = 'computeddata_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 11
+WHERE "collection" = 'notifications_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 12
+WHERE "collection" = 'faqs_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 14
+WHERE "collection" = 'applications_group';
+
+UPDATE "public"."directus_collections"
+SET "group" = 'lists'
+WHERE "collection" = 'lists_relations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 16
+WHERE "collection" = 'timedmetadata';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 17
+WHERE "collection" = 'materialized_views_meta';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 18
+WHERE "collection" = 'images';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 19
+WHERE "collection" = 'styledimages';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 20
+WHERE "collection" = 'translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 6
+WHERE "collection" = 'achievements_group';
+
+UPDATE "public"."directus_collections"
+SET "sort"  = 8,
+    "group" = NULL
+WHERE "collection" = 'songs_group';
+
+UPDATE "public"."directus_collections"
+SET "sort"  = 9,
+    "group" = NULL
+WHERE "collection" = 'persons';
+
+UPDATE "public"."directus_collections"
+SET "sort"  = 10,
+    "group" = NULL
+WHERE "collection" = 'phrases';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 13
+WHERE "collection" = 'messages_group';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 21
+WHERE "collection" = 'songcollections_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 22
+WHERE "collection" = 'phrases_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 24
+WHERE "collection" = 'songs_translations';
+
+UPDATE "public"."directus_collections"
+SET "sort" = 25
+WHERE "collection" = 'timedmetadata_persons';
+
+DELETE
+FROM "public"."directus_collections"
+WHERE "collection" = 'Metadata';
+
+--- END SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (69, 'categories', 'appear_in_search', 'cast-boolean', 'boolean', '{
+  "label": "Appear in search"
+}', NULL, NULL, false, false, 8, 'full', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (179, 'lists', 'id', NULL, 'input', NULL, NULL, NULL, true, true, 1, 'full', NULL, NULL, NULL, false, NULL, NULL,
+        NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (180, 'lists', 'legacy_category_id', NULL, 'input', NULL, NULL, NULL, false, false, NULL, 'full', NULL, NULL,
+        NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (72, 'categories', 'episodes', 'm2m', 'list-m2m', '{
+  "enableCreate": false,
+  "template": "{{episodes_id.translations}}"
+}', 'related-values', '{
+  "template": "{{episodes_id.translations}}"
+}', false, false, NULL, 'full', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (73, 'categories', 'id', NULL, 'input', NULL, NULL, NULL, true, true, 1, 'full', NULL, NULL, NULL, false, NULL,
+        NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (74, 'categories', 'legacy_id', NULL, 'input', NULL, NULL, NULL, false, true, NULL, 'full', NULL, NULL, NULL,
+        false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (75, 'categories', 'parent_id', NULL, 'select-dropdown-m2o', NULL, NULL, NULL, false, true, 9, 'full', NULL,
+        NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (76, 'categories', 'sort', NULL, 'input', NULL, NULL, NULL, false, true, 2, 'full', NULL, NULL, NULL, false,
+        NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (77, 'categories', 'subcategories', 'o2m', 'list-o2m-tree-view', NULL, NULL, NULL, false, true, 10, 'full', NULL,
+        NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (78, 'categories', 'translations', 'translations', 'translations', '{
+  "languageField": "code"
+}', 'translations', '{
+  "defaultLanguage": "no",
+  "languageField": "code",
+  "template": "{{name}}",
+  "userLanguage": true
+}', false, false, 7, 'full', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (79, 'categories', 'user_created', 'user-created', 'select-dropdown-m2o', '{
+  "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+}', 'user', NULL, true, true, 3, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (80, 'categories', 'user_updated', 'user-updated', 'select-dropdown-m2o', '{
+  "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+}', 'user', NULL, true, true, 5, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (81, 'categories_translations', 'categories_id', NULL, NULL, NULL, NULL, NULL, false, true, NULL, 'full', NULL,
+        NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (150, 'episodes_categories', 'categories_id', NULL, NULL, NULL, NULL, NULL, false, true, NULL, 'full', NULL,
+        NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (181, 'lists', 'legacy_name_id', NULL, 'input', NULL, NULL, NULL, false, false, NULL, 'full', NULL, NULL, NULL,
+        false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (182, 'lists', 'name', NULL, 'input', NULL, NULL, NULL, false, false, 6, 'full', NULL, NULL, NULL, true, NULL,
+        NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (184, 'lists', 'user_created', 'user-created', 'select-dropdown-m2o', '{
+  "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+}', 'user', NULL, true, true, 2, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (185, 'lists', 'user_updated', 'user-updated', 'select-dropdown-m2o', '{
+  "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+}', 'user', NULL, true, true, 4, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (189, 'lists_relations', 'lists_id', NULL, NULL, NULL, NULL, NULL, false, true, NULL, 'full', NULL, NULL, NULL,
+        false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (71, 'categories', 'date_updated', 'date-created,date-updated', 'datetime', NULL, 'datetime', '{
+  "relative": true
+}', true, true, 6, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (178, 'lists', 'date_updated', 'date-created,date-updated', 'datetime', NULL, 'datetime', '{
+  "relative": true
+}', true, true, 5, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (70, 'categories', 'date_created', 'date-created', 'datetime', NULL, 'datetime', '{
+  "relative": true
+}', true, true, 4, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (183, 'lists', 'relations', 'm2a', 'list-m2a', '{}', 'related-values', '{
+  "template": "{{item:shows}}{{item:episodes}}{{item:shows.translations}}"
+}', false, false, 7, 'full', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+UPDATE "public"."directus_fields"
+SET "hidden" = true
+WHERE "id" = 884;
+
+UPDATE "public"."directus_fields"
+SET "hidden" = false
+WHERE "id" = 1065;
+
+UPDATE "public"."directus_fields"
+SET "required" = false
+WHERE "id" = 1062;
+
+UPDATE "public"."directus_fields"
+SET "width" = 'half'
+WHERE "id" = 1049;
+
+UPDATE "public"."directus_fields"
+SET "hidden" = false
+WHERE "id" = 1067;
+
+UPDATE "public"."directus_fields"
+SET "required" = false
+WHERE "id" = 1077;
+
+UPDATE "public"."directus_fields"
+SET "sort"  = 2,
+    "group" = NULL
+WHERE "id" = 1191;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 3
+WHERE "id" = 1192;
+
+UPDATE "public"."directus_fields"
+SET "width" = 'half'
+WHERE "id" = 1190;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 5
+WHERE "id" = 1194;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 6
+WHERE "id" = 1195;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 8
+WHERE "id" = 1196;
+
+UPDATE "public"."directus_fields"
+SET "hidden" = true,
+    "sort"   = 9
+WHERE "id" = 1202;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 7
+WHERE "id" = 1207;
+
+UPDATE "public"."directus_fields"
+SET "interface" = NULL
+WHERE "id" = 1222;
+
+UPDATE "public"."directus_fields"
+SET "interface" = NULL
+WHERE "id" = 1221;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 4
+WHERE "id" = 1193;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 6
+WHERE "id" = 1356;
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (177, 'lists', 'date_created', 'date-created', 'datetime', NULL, 'datetime', '{
+  "relative": true
+}', true, true, 3, 'half', NULL, NULL, NULL, false, NULL, NULL, NULL);
+
+UPDATE "public"."directus_fields"
+SET "width" = 'half'
+WHERE "id" = 1351;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 2
+WHERE "id" = 1352;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 3
+WHERE "id" = 1353;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 4
+WHERE "id" = 1354;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 5
+WHERE "id" = 1355;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 1
+WHERE "id" = 1382;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 2
+WHERE "id" = 1200;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 3
+WHERE "id" = 1201;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 5
+WHERE "id" = 1217;
+
+UPDATE "public"."directus_fields"
+SET "sort" = 4
+WHERE "id" = 1206;
+
+--- END SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_permissions" RECORDS ---
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (120, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'lists', 'share', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (202, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'categories', 'delete', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (123, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'lists', 'update', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (203, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'categories', 'read', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (204, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'categories', 'share', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (122, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'lists', 'create', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (121, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'lists', 'read', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (201, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'categories', 'update', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (124, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'lists', 'delete', '{}', '{}', NULL, '*');
+
+INSERT INTO "public"."directus_permissions" ("id", "role", "collection", "action", "permissions", "validation",
+                                             "presets", "fields")
+VALUES (200, '156d86ef-4c0e-4886-8bee-3a3c346fdb23', 'categories', 'create', '{}', '{}', NULL, '*');
+
+--- END SYNCHRONIZE TABLE "public"."directus_permissions" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (19, 'categories', 'parent_id', 'categories', 'subcategories', NULL, NULL, NULL, NULL, 'nullify');
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (20, 'categories', 'user_created', 'directus_users', NULL, NULL, NULL, NULL, NULL, 'nullify');
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (21, 'categories', 'user_updated', 'directus_users', NULL, NULL, NULL, NULL, NULL, 'nullify');
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (22, 'categories_translations', 'categories_id', 'categories', 'translations', NULL, NULL, 'languages_code',
+        NULL, 'nullify');
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (44, 'episodes_categories', 'categories_id', 'categories', 'episodes', NULL, NULL, 'episodes_id', NULL,
+        'delete');
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (56, 'lists', 'user_created', 'directus_users', NULL, NULL, NULL, NULL, NULL, 'nullify');
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (57, 'lists', 'user_updated', 'directus_users', NULL, NULL, NULL, NULL, NULL, 'nullify');
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (59, 'lists_relations', 'lists_id', 'lists', 'relations', NULL, NULL, 'item', 'sort', 'delete');
+
+--- END SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---

--- a/migrations/00236_fix_indexes.sql
+++ b/migrations/00236_fix_indexes.sql
@@ -72,6 +72,8 @@ ALTER TABLE IF EXISTS "public"."events_translations"
 
 DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
 
+DELETE FROM "public"."events_translations" WHERE events_id IS NULL;
+
 ALTER TABLE IF EXISTS "public"."events_translations"
     ALTER COLUMN "events_id" SET NOT NULL;
 
@@ -141,6 +143,8 @@ ALTER TABLE IF EXISTS "public"."collections_entries"
 ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
     DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messages_id_foreign";
 
+DELETE FROM messages_messagetemplates WHERE messages_id IS NULL;
+
 ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
     ALTER COLUMN "messages_id" SET NOT NULL;
 
@@ -166,6 +170,8 @@ COMMENT ON CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" ON
 
 ALTER TABLE IF EXISTS "public"."collections_translations"
     DROP CONSTRAINT IF EXISTS "collections_translations_collections_id_foreign";
+
+DELETE FROM collections_translations WHERE collections_id IS NULL;
 
 ALTER TABLE IF EXISTS "public"."collections_translations"
     ALTER COLUMN "collections_id" SET NOT NULL;
@@ -388,6 +394,8 @@ COMMENT ON INDEX "public"."prompts_translations_prompts_id_languages_code_uindex
 ALTER TABLE IF EXISTS "public"."prompts_targets"
     DROP CONSTRAINT IF EXISTS "prompts_targets_prompts_id_foreign";
 
+DELETE FROM prompts_targets WHERE prompts_id IS NULL;
+
 ALTER TABLE IF EXISTS "public"."prompts_targets"
     ALTER COLUMN "prompts_id" SET NOT NULL;
 
@@ -561,6 +569,8 @@ COMMENT ON CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" ON "
 ALTER TABLE IF EXISTS "public"."games_styledimages"
     DROP CONSTRAINT IF EXISTS "games_styledimages_games_id_foreign";
 
+DELETE FROM games_styledimages WHERE games_id IS NULL;
+
 ALTER TABLE IF EXISTS "public"."games_styledimages"
     ALTER COLUMN "games_id" SET NOT NULL;
 
@@ -603,6 +613,8 @@ ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
     DROP CONSTRAINT IF EXISTS "messagetemplates_translations_messagetemplates_id_foreign";
 
 DROP INDEX IF EXISTS messagetemplates_translations_messagetemplates_id_languages_cod;
+
+DELETE FROM messagetemplates_translations WHERE messagetemplates_id IS NULL;
 
 ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
     ALTER COLUMN "messagetemplates_id" SET NOT NULL;

--- a/migrations/00236_fix_indexes.sql
+++ b/migrations/00236_fix_indexes.sql
@@ -6,34 +6,40 @@
 
 --- BEGIN ALTER TABLE "public"."tags_translations" ---
 
-ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_tags_id_foreign";
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    DROP CONSTRAINT IF EXISTS "tags_translations_tags_id_foreign";
 
 DROP INDEX IF EXISTS tags_translations_languages_code_tags_id_uindex;
 
 ALTER TABLE IF EXISTS "public"."tags_translations"
-	ALTER COLUMN "tags_id" SET NOT NULL;
+    ALTER COLUMN "tags_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    ADD CONSTRAINT "tags_translations_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "tags_translations_tags_id_foreign" ON "public"."tags_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    DROP CONSTRAINT IF EXISTS "tags_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    ADD CONSTRAINT "tags_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "tags_translations_languages_code_foreign" ON "public"."tags_translations" IS NULL;
 
 CREATE UNIQUE INDEX tags_translations_languages_code_tags_id_uindex ON public.tags_translations USING btree (languages_code, tags_id);
 
-COMMENT ON INDEX "public"."tags_translations_languages_code_tags_id_uindex"  IS NULL;
+COMMENT ON INDEX "public"."tags_translations_languages_code_tags_id_uindex" IS NULL;
 
 --- END ALTER TABLE "public"."tags_translations" ---
 
 --- BEGIN ALTER TABLE "public"."playlists" ---
 
-ALTER TABLE IF EXISTS "public"."playlists" DROP CONSTRAINT IF EXISTS "playlists_collection_id_foreign";
+ALTER TABLE IF EXISTS "public"."playlists"
+    DROP CONSTRAINT IF EXISTS "playlists_collection_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."playlists" ADD CONSTRAINT "playlists_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE RESTRICT;
+ALTER TABLE IF EXISTS "public"."playlists"
+    ADD CONSTRAINT "playlists_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections (id) ON DELETE RESTRICT;
 
 COMMENT ON CONSTRAINT "playlists_collection_id_foreign" ON "public"."playlists" IS NULL;
 
@@ -41,15 +47,19 @@ COMMENT ON CONSTRAINT "playlists_collection_id_foreign" ON "public"."playlists" 
 
 --- BEGIN ALTER TABLE "public"."playlists_translations" ---
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    DROP CONSTRAINT IF EXISTS "playlists_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    ADD CONSTRAINT "playlists_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "playlists_translations_languages_code_foreign" ON "public"."playlists_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_playlists_id_foreign";
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    DROP CONSTRAINT IF EXISTS "playlists_translations_playlists_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_playlists_id_foreign" FOREIGN KEY (playlists_id) REFERENCES playlists(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    ADD CONSTRAINT "playlists_translations_playlists_id_foreign" FOREIGN KEY (playlists_id) REFERENCES playlists (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "playlists_translations_playlists_id_foreign" ON "public"."playlists_translations" IS NULL;
 
@@ -57,52 +67,60 @@ COMMENT ON CONSTRAINT "playlists_translations_playlists_id_foreign" ON "public".
 
 --- BEGIN ALTER TABLE "public"."events_translations" ---
 
-ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_events_id_foreign";
+ALTER TABLE IF EXISTS "public"."events_translations"
+    DROP CONSTRAINT IF EXISTS "events_translations_events_id_foreign";
 
 DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
 
 ALTER TABLE IF EXISTS "public"."events_translations"
-	ALTER COLUMN "events_id" SET NOT NULL;
+    ALTER COLUMN "events_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."events_translations"
+    DROP CONSTRAINT IF EXISTS "events_translations_languages_code_foreign";
 
 DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
 
 ALTER TABLE IF EXISTS "public"."events_translations"
-	ALTER COLUMN "languages_code" SET NOT NULL,
-	ALTER COLUMN "languages_code" DROP DEFAULT ;
+    ALTER COLUMN "languages_code" SET NOT NULL,
+    ALTER COLUMN "languages_code" DROP DEFAULT;
 
-ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_events_id_foreign" FOREIGN KEY (events_id) REFERENCES events(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."events_translations"
+    ADD CONSTRAINT "events_translations_events_id_foreign" FOREIGN KEY (events_id) REFERENCES events (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "events_translations_events_id_foreign" ON "public"."events_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."events_translations"
+    ADD CONSTRAINT "events_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "events_translations_languages_code_foreign" ON "public"."events_translations" IS NULL;
 
 CREATE INDEX events_translations_events_id_languages_code_index ON public.events_translations USING btree (events_id, languages_code);
 
-COMMENT ON INDEX "public"."events_translations_events_id_languages_code_index"  IS NULL;
+COMMENT ON INDEX "public"."events_translations_events_id_languages_code_index" IS NULL;
 
 --- END ALTER TABLE "public"."events_translations" ---
 
 --- BEGIN ALTER TABLE "public"."shows_tags" ---
 
-ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_shows_id_foreign";
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    DROP CONSTRAINT IF EXISTS "shows_tags_shows_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."shows_tags"
-	ALTER COLUMN "shows_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_tags_id_foreign";
+    ALTER COLUMN "shows_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."shows_tags"
-	ALTER COLUMN "tags_id" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "shows_tags_tags_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    ALTER COLUMN "tags_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    ADD CONSTRAINT "shows_tags_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "shows_tags_tags_id_foreign" ON "public"."shows_tags" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_shows_id_foreign" FOREIGN KEY (shows_id) REFERENCES shows(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    ADD CONSTRAINT "shows_tags_shows_id_foreign" FOREIGN KEY (shows_id) REFERENCES shows (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "shows_tags_shows_id_foreign" ON "public"."shows_tags" IS NULL;
 
@@ -111,30 +129,34 @@ COMMENT ON CONSTRAINT "shows_tags_shows_id_foreign" ON "public"."shows_tags" IS 
 --- BEGIN ALTER TABLE "public"."collections_entries" ---
 
 ALTER TABLE IF EXISTS "public"."collections_entries"
-	ALTER COLUMN "item" SET NOT NULL;
+    ALTER COLUMN "item" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."collections_entries"
-	ALTER COLUMN "collection" SET NOT NULL;
+    ALTER COLUMN "collection" SET NOT NULL;
 
 --- END ALTER TABLE "public"."collections_entries" ---
 
 --- BEGIN ALTER TABLE "public"."messages_messagetemplates" ---
 
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messages_id_foreign";
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messages_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
-	ALTER COLUMN "messages_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messagetemplates_id_foreign";
+    ALTER COLUMN "messages_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
-	ALTER COLUMN "messagetemplates_id" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messagetemplates_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messages_id_foreign" FOREIGN KEY (messages_id) REFERENCES messages(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    ALTER COLUMN "messagetemplates_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    ADD CONSTRAINT "messages_messagetemplates_messages_id_foreign" FOREIGN KEY (messages_id) REFERENCES messages (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "messages_messagetemplates_messages_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    ADD CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
 
@@ -142,21 +164,25 @@ COMMENT ON CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" ON
 
 --- BEGIN ALTER TABLE "public"."collections_translations" ---
 
-ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_collections_id_foreign";
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    DROP CONSTRAINT IF EXISTS "collections_translations_collections_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."collections_translations"
-	ALTER COLUMN "collections_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_languages_code_foreign";
+    ALTER COLUMN "collections_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."collections_translations"
-	ALTER COLUMN "languages_code" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "collections_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_collections_id_foreign" FOREIGN KEY (collections_id) REFERENCES collections(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    ALTER COLUMN "languages_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    ADD CONSTRAINT "collections_translations_collections_id_foreign" FOREIGN KEY (collections_id) REFERENCES collections (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "collections_translations_collections_id_foreign" ON "public"."collections_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    ADD CONSTRAINT "collections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "collections_translations_languages_code_foreign" ON "public"."collections_translations" IS NULL;
 
@@ -164,43 +190,49 @@ COMMENT ON CONSTRAINT "collections_translations_languages_code_foreign" ON "publ
 
 --- BEGIN ALTER TABLE "public"."notificationtemplates_translations" ---
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_notific__402aa733_foreign";
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_notific__402aa733_foreign";
 
 DROP INDEX IF EXISTS notificationtemplates_translations_notificationtemplates_id_lan;
 
 ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
-	ALTER COLUMN "notificationtemplates_id" SET NOT NULL;
+    ALTER COLUMN "notificationtemplates_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    ADD CONSTRAINT "notificationtemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "notificationtemplates_translations_languages_code_foreign" ON "public"."notificationtemplates_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" FOREIGN KEY (notificationtemplates_id) REFERENCES notificationtemplates(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    ADD CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" FOREIGN KEY (notificationtemplates_id) REFERENCES notificationtemplates (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" ON "public"."notificationtemplates_translations" IS NULL;
 
 CREATE UNIQUE INDEX notificationtemplates_translations_notificationtemplates_id_lan ON public.notificationtemplates_translations USING btree (notificationtemplates_id, languages_code);
 
-COMMENT ON INDEX "public"."notificationtemplates_translations_notificationtemplates_id_lan"  IS NULL;
+COMMENT ON INDEX "public"."notificationtemplates_translations_notificationtemplates_id_lan" IS NULL;
 
 --- END ALTER TABLE "public"."notificationtemplates_translations" ---
 
 --- BEGIN ALTER TABLE "public"."lessons_relations" ---
 
-ALTER TABLE IF EXISTS "public"."lessons_relations" DROP CONSTRAINT IF EXISTS "lessons_relations_lessons_id_foreign";
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+    DROP CONSTRAINT IF EXISTS "lessons_relations_lessons_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."lessons_relations"
-	ALTER COLUMN "lessons_id" SET NOT NULL;
+    ALTER COLUMN "lessons_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."lessons_relations"
-	ALTER COLUMN "item" SET NOT NULL;
+    ALTER COLUMN "item" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."lessons_relations"
-	ALTER COLUMN "collection" SET NOT NULL;
+    ALTER COLUMN "collection" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."lessons_relations" ADD CONSTRAINT "lessons_relations_lessons_id_foreign" FOREIGN KEY (lessons_id) REFERENCES lessons(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+    ADD CONSTRAINT "lessons_relations_lessons_id_foreign" FOREIGN KEY (lessons_id) REFERENCES lessons (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "lessons_relations_lessons_id_foreign" ON "public"."lessons_relations" IS NULL;
 
@@ -208,30 +240,36 @@ COMMENT ON CONSTRAINT "lessons_relations_lessons_id_foreign" ON "public"."lesson
 
 --- BEGIN ALTER TABLE "public"."achievements_images" ---
 
-ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_image_foreign";
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    DROP CONSTRAINT IF EXISTS "achievements_images_image_foreign";
 
 ALTER TABLE IF EXISTS "public"."achievements_images"
-	ALTER COLUMN "image" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_achievement_id_foreign";
+    ALTER COLUMN "image" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."achievements_images"
-	ALTER COLUMN "achievement_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_language_foreign";
+    DROP CONSTRAINT IF EXISTS "achievements_images_achievement_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."achievements_images"
-	ALTER COLUMN "language" SET NOT NULL;
+    ALTER COLUMN "achievement_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_language_foreign" FOREIGN KEY (language) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    DROP CONSTRAINT IF EXISTS "achievements_images_language_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ALTER COLUMN "language" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ADD CONSTRAINT "achievements_images_language_foreign" FOREIGN KEY (language) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievements_images_language_foreign" ON "public"."achievements_images" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_image_foreign" FOREIGN KEY (image) REFERENCES directus_files(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ADD CONSTRAINT "achievements_images_image_foreign" FOREIGN KEY (image) REFERENCES directus_files (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievements_images_image_foreign" ON "public"."achievements_images" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_achievement_id_foreign" FOREIGN KEY (achievement_id) REFERENCES achievements(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ADD CONSTRAINT "achievements_images_achievement_id_foreign" FOREIGN KEY (achievement_id) REFERENCES achievements (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievements_images_achievement_id_foreign" ON "public"."achievements_images" IS NULL;
 
@@ -239,12 +277,14 @@ COMMENT ON CONSTRAINT "achievements_images_achievement_id_foreign" ON "public"."
 
 --- BEGIN ALTER TABLE "public"."lessons_images" ---
 
-ALTER TABLE IF EXISTS "public"."lessons_images" DROP CONSTRAINT IF EXISTS "lessons_images_lesson_id_foreign";
+ALTER TABLE IF EXISTS "public"."lessons_images"
+    DROP CONSTRAINT IF EXISTS "lessons_images_lesson_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."lessons_images"
-	ALTER COLUMN "lesson_id" SET NOT NULL;
+    ALTER COLUMN "lesson_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."lessons_images" ADD CONSTRAINT "lessons_images_lesson_id_foreign" FOREIGN KEY (lesson_id) REFERENCES lessons(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."lessons_images"
+    ADD CONSTRAINT "lessons_images_lesson_id_foreign" FOREIGN KEY (lesson_id) REFERENCES lessons (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "lessons_images_lesson_id_foreign" ON "public"."lessons_images" IS NULL;
 
@@ -252,15 +292,19 @@ COMMENT ON CONSTRAINT "lessons_images_lesson_id_foreign" ON "public"."lessons_im
 
 --- BEGIN ALTER TABLE "public"."achievements_translations" ---
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_achievements_id_foreign";
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    DROP CONSTRAINT IF EXISTS "achievements_translations_achievements_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_achievements_id_foreign" FOREIGN KEY (achievements_id) REFERENCES achievements(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    ADD CONSTRAINT "achievements_translations_achievements_id_foreign" FOREIGN KEY (achievements_id) REFERENCES achievements (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievements_translations_achievements_id_foreign" ON "public"."achievements_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    DROP CONSTRAINT IF EXISTS "achievements_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    ADD CONSTRAINT "achievements_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievements_translations_languages_code_foreign" ON "public"."achievements_translations" IS NULL;
 
@@ -268,21 +312,25 @@ COMMENT ON CONSTRAINT "achievements_translations_languages_code_foreign" ON "pub
 
 --- BEGIN ALTER TABLE "public"."targets_usergroups" ---
 
-ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_targets_id_foreign";
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    DROP CONSTRAINT IF EXISTS "targets_usergroups_targets_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."targets_usergroups"
-	ALTER COLUMN "targets_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_usergroups_code_foreign";
+    ALTER COLUMN "targets_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."targets_usergroups"
-	ALTER COLUMN "usergroups_code" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "targets_usergroups_usergroups_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    ALTER COLUMN "usergroups_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    ADD CONSTRAINT "targets_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "targets_usergroups_usergroups_code_foreign" ON "public"."targets_usergroups" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    ADD CONSTRAINT "targets_usergroups_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "targets_usergroups_targets_id_foreign" ON "public"."targets_usergroups" IS NULL;
 
@@ -290,21 +338,25 @@ COMMENT ON CONSTRAINT "targets_usergroups_targets_id_foreign" ON "public"."targe
 
 --- BEGIN ALTER TABLE "public"."notifications_targets" ---
 
-ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_notifications_id_foreign";
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    DROP CONSTRAINT IF EXISTS "notifications_targets_notifications_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."notifications_targets"
-	ALTER COLUMN "notifications_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_targets_id_foreign";
+    ALTER COLUMN "notifications_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."notifications_targets"
-	ALTER COLUMN "targets_id" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "notifications_targets_targets_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    ALTER COLUMN "targets_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    ADD CONSTRAINT "notifications_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "notifications_targets_targets_id_foreign" ON "public"."notifications_targets" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_notifications_id_foreign" FOREIGN KEY (notifications_id) REFERENCES notifications(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    ADD CONSTRAINT "notifications_targets_notifications_id_foreign" FOREIGN KEY (notifications_id) REFERENCES notifications (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "notifications_targets_notifications_id_foreign" ON "public"."notifications_targets" IS NULL;
 
@@ -312,40 +364,46 @@ COMMENT ON CONSTRAINT "notifications_targets_notifications_id_foreign" ON "publi
 
 --- BEGIN ALTER TABLE "public"."prompts_translations" ---
 
-ALTER TABLE IF EXISTS "public"."prompts_translations" DROP CONSTRAINT IF EXISTS "prompts_translations_prompts_id_foreign";
+ALTER TABLE IF EXISTS "public"."prompts_translations"
+    DROP CONSTRAINT IF EXISTS "prompts_translations_prompts_id_foreign";
 
 DROP INDEX IF EXISTS prompts_translations_prompts_id_languages_code_uindex;
 
 ALTER TABLE IF EXISTS "public"."prompts_translations"
-	ALTER COLUMN "prompts_id" SET NOT NULL;
+    ALTER COLUMN "prompts_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."prompts_translations" ADD CONSTRAINT "prompts_translations_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."prompts_translations"
+    ADD CONSTRAINT "prompts_translations_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "prompts_translations_prompts_id_foreign" ON "public"."prompts_translations" IS NULL;
 
 CREATE UNIQUE INDEX prompts_translations_prompts_id_languages_code_uindex ON public.prompts_translations USING btree (prompts_id, languages_code);
 
-COMMENT ON INDEX "public"."prompts_translations_prompts_id_languages_code_uindex"  IS NULL;
+COMMENT ON INDEX "public"."prompts_translations_prompts_id_languages_code_uindex" IS NULL;
 
 --- END ALTER TABLE "public"."prompts_translations" ---
 
 --- BEGIN ALTER TABLE "public"."prompts_targets" ---
 
-ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_prompts_id_foreign";
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    DROP CONSTRAINT IF EXISTS "prompts_targets_prompts_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."prompts_targets"
-	ALTER COLUMN "prompts_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_targets_id_foreign";
+    ALTER COLUMN "prompts_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."prompts_targets"
-	ALTER COLUMN "targets_id" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "prompts_targets_targets_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    ALTER COLUMN "targets_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    ADD CONSTRAINT "prompts_targets_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "prompts_targets_prompts_id_foreign" ON "public"."prompts_targets" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    ADD CONSTRAINT "prompts_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "prompts_targets_targets_id_foreign" ON "public"."prompts_targets" IS NULL;
 
@@ -353,21 +411,25 @@ COMMENT ON CONSTRAINT "prompts_targets_targets_id_foreign" ON "public"."prompts_
 
 --- BEGIN ALTER TABLE "public"."achievementconditions_studytopics" ---
 
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_achievem__2e3395b2_foreign";
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_achievem__2e3395b2_foreign";
 
 ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
-	ALTER COLUMN "achievementconditions_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_studytopics_id_foreign";
+    ALTER COLUMN "achievementconditions_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
-	ALTER COLUMN "studytopics_id" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_studytopics_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" FOREIGN KEY (studytopics_id) REFERENCES studytopics(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    ALTER COLUMN "studytopics_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    ADD CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" FOREIGN KEY (studytopics_id) REFERENCES studytopics (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" FOREIGN KEY (achievementconditions_id) REFERENCES achievementconditions(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    ADD CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" FOREIGN KEY (achievementconditions_id) REFERENCES achievementconditions (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
 
@@ -375,21 +437,25 @@ COMMENT ON CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_fore
 
 --- BEGIN ALTER TABLE "public"."faqs_usergroups" ---
 
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_faqs_id_foreign";
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    DROP CONSTRAINT IF EXISTS "faqs_usergroups_faqs_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."faqs_usergroups"
-	ALTER COLUMN "faqs_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_usergroups_code_foreign";
+    ALTER COLUMN "faqs_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."faqs_usergroups"
-	ALTER COLUMN "usergroups_code" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "faqs_usergroups_usergroups_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_faqs_id_foreign" FOREIGN KEY (faqs_id) REFERENCES faqs(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    ALTER COLUMN "usergroups_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    ADD CONSTRAINT "faqs_usergroups_faqs_id_foreign" FOREIGN KEY (faqs_id) REFERENCES faqs (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "faqs_usergroups_faqs_id_foreign" ON "public"."faqs_usergroups" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    ADD CONSTRAINT "faqs_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "faqs_usergroups_usergroups_code_foreign" ON "public"."faqs_usergroups" IS NULL;
 
@@ -397,22 +463,26 @@ COMMENT ON CONSTRAINT "faqs_usergroups_usergroups_code_foreign" ON "public"."faq
 
 --- BEGIN ALTER TABLE "public"."assetstreams_audio_languages" ---
 
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_assetstreams_id_foreign";
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_assetstreams_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
-	ALTER COLUMN "assetstreams_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_languages_code_foreign";
+    ALTER COLUMN "assetstreams_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
-	ALTER COLUMN "languages_code" SET NOT NULL,
-	ALTER COLUMN "languages_code" DROP DEFAULT ;
+    DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    ALTER COLUMN "languages_code" SET NOT NULL,
+    ALTER COLUMN "languages_code" DROP DEFAULT;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    ADD CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    ADD CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code);
 
 COMMENT ON CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
 
@@ -420,22 +490,26 @@ COMMENT ON CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" ON "
 
 --- BEGIN ALTER TABLE "public"."assetstreams_subtitle_languages" ---
 
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_assetstreams_id_foreign";
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_assetstreams_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
-	ALTER COLUMN "assetstreams_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_languages_code_foreign";
+    ALTER COLUMN "assetstreams_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
-	ALTER COLUMN "languages_code" SET NOT NULL,
-	ALTER COLUMN "languages_code" DROP DEFAULT ;
+    DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    ALTER COLUMN "languages_code" SET NOT NULL,
+    ALTER COLUMN "languages_code" DROP DEFAULT;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    ADD CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    ADD CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code);
 
 COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
 
@@ -443,21 +517,25 @@ COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" O
 
 --- BEGIN ALTER TABLE "public"."applicationgroups_usergroups" ---
 
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_applicationgroups_id_foreign";
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_applicationgroups_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
-	ALTER COLUMN "applicationgroups_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_usergroups_code_foreign";
+    ALTER COLUMN "applicationgroups_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
-	ALTER COLUMN "usergroups_code" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_usergroups_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    ALTER COLUMN "usergroups_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    ADD CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" FOREIGN KEY (applicationgroups_id) REFERENCES applicationgroups(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    ADD CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" FOREIGN KEY (applicationgroups_id) REFERENCES applicationgroups (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
 
@@ -465,12 +543,14 @@ COMMENT ON CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign
 
 --- BEGIN ALTER TABLE "public"."timedmetadata_translations" ---
 
-ALTER TABLE IF EXISTS "public"."timedmetadata_translations" DROP CONSTRAINT IF EXISTS "timedmetadata_translations_timedmetadata_id_foreign";
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
+    DROP CONSTRAINT IF EXISTS "timedmetadata_translations_timedmetadata_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
-	ALTER COLUMN "timedmetadata_id" SET NOT NULL;
+    ALTER COLUMN "timedmetadata_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."timedmetadata_translations" ADD CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" FOREIGN KEY (timedmetadata_id) REFERENCES timedmetadata(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
+    ADD CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" FOREIGN KEY (timedmetadata_id) REFERENCES timedmetadata (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" ON "public"."timedmetadata_translations" IS NULL;
 
@@ -478,21 +558,25 @@ COMMENT ON CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" ON "
 
 --- BEGIN ALTER TABLE "public"."games_styledimages" ---
 
-ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_games_id_foreign";
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    DROP CONSTRAINT IF EXISTS "games_styledimages_games_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."games_styledimages"
-	ALTER COLUMN "games_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_styledimages_id_foreign";
+    ALTER COLUMN "games_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."games_styledimages"
-	ALTER COLUMN "styledimages_id" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "games_styledimages_styledimages_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_games_id_foreign" FOREIGN KEY (games_id) REFERENCES games(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    ALTER COLUMN "styledimages_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    ADD CONSTRAINT "games_styledimages_games_id_foreign" FOREIGN KEY (games_id) REFERENCES games (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "games_styledimages_games_id_foreign" ON "public"."games_styledimages" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_styledimages_id_foreign" FOREIGN KEY (styledimages_id) REFERENCES styledimages(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    ADD CONSTRAINT "games_styledimages_styledimages_id_foreign" FOREIGN KEY (styledimages_id) REFERENCES styledimages (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "games_styledimages_styledimages_id_foreign" ON "public"."games_styledimages" IS NULL;
 
@@ -500,12 +584,14 @@ COMMENT ON CONSTRAINT "games_styledimages_styledimages_id_foreign" ON "public"."
 
 --- BEGIN ALTER TABLE "public"."calendarentries_translations" ---
 
-ALTER TABLE IF EXISTS "public"."calendarentries_translations" DROP CONSTRAINT IF EXISTS "calendarentries_translations_calendarentries_id_foreign";
+ALTER TABLE IF EXISTS "public"."calendarentries_translations"
+    DROP CONSTRAINT IF EXISTS "calendarentries_translations_calendarentries_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."calendarentries_translations"
-	ALTER COLUMN "calendarentries_id" SET NOT NULL;
+    ALTER COLUMN "calendarentries_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."calendarentries_translations" ADD CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" FOREIGN KEY (calendarentries_id) REFERENCES calendarentries(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."calendarentries_translations"
+    ADD CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" FOREIGN KEY (calendarentries_id) REFERENCES calendarentries (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" ON "public"."calendarentries_translations" IS NULL;
 
@@ -513,46 +599,54 @@ COMMENT ON CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" 
 
 --- BEGIN ALTER TABLE "public"."messagetemplates_translations" ---
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_messagetemplates_id_foreign";
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    DROP CONSTRAINT IF EXISTS "messagetemplates_translations_messagetemplates_id_foreign";
 
 DROP INDEX IF EXISTS messagetemplates_translations_messagetemplates_id_languages_cod;
 
 ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
-	ALTER COLUMN "messagetemplates_id" SET NOT NULL;
+    ALTER COLUMN "messagetemplates_id" SET NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    ADD CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" ON "public"."messagetemplates_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    DROP CONSTRAINT IF EXISTS "messagetemplates_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    ADD CONSTRAINT "messagetemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "messagetemplates_translations_languages_code_foreign" ON "public"."messagetemplates_translations" IS NULL;
 
 CREATE UNIQUE INDEX messagetemplates_translations_messagetemplates_id_languages_cod ON public.messagetemplates_translations USING btree (messagetemplates_id, languages_code);
 
-COMMENT ON INDEX "public"."messagetemplates_translations_messagetemplates_id_languages_cod"  IS NULL;
+COMMENT ON INDEX "public"."messagetemplates_translations_messagetemplates_id_languages_cod" IS NULL;
 
 --- END ALTER TABLE "public"."messagetemplates_translations" ---
 
 --- BEGIN ALTER TABLE "public"."songcollections_translations" ---
 
-ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_songcollections_id_foreign";
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    DROP CONSTRAINT IF EXISTS "songcollections_translations_songcollections_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."songcollections_translations"
-	ALTER COLUMN "songcollections_id" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_languages_code_foreign";
+    ALTER COLUMN "songcollections_id" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."songcollections_translations"
-	ALTER COLUMN "languages_code" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "songcollections_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    ALTER COLUMN "languages_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    ADD CONSTRAINT "songcollections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "songcollections_translations_languages_code_foreign" ON "public"."songcollections_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_songcollections_id_foreign" FOREIGN KEY (songcollections_id) REFERENCES songcollections(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    ADD CONSTRAINT "songcollections_translations_songcollections_id_foreign" FOREIGN KEY (songcollections_id) REFERENCES songcollections (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "songcollections_translations_songcollections_id_foreign" ON "public"."songcollections_translations" IS NULL;
 
@@ -560,21 +654,25 @@ COMMENT ON CONSTRAINT "songcollections_translations_songcollections_id_foreign" 
 
 --- BEGIN ALTER TABLE "public"."phrases_translations" ---
 
-ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_phrases_key_foreign";
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    DROP CONSTRAINT IF EXISTS "phrases_translations_phrases_key_foreign";
 
 ALTER TABLE IF EXISTS "public"."phrases_translations"
-	ALTER COLUMN "phrases_key" SET NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_languages_code_foreign";
+    ALTER COLUMN "phrases_key" SET NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."phrases_translations"
-	ALTER COLUMN "languages_code" SET NOT NULL;
+    DROP CONSTRAINT IF EXISTS "phrases_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    ALTER COLUMN "languages_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    ADD CONSTRAINT "phrases_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "phrases_translations_languages_code_foreign" ON "public"."phrases_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_phrases_key_foreign" FOREIGN KEY (phrases_key) REFERENCES phrases(key) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    ADD CONSTRAINT "phrases_translations_phrases_key_foreign" FOREIGN KEY (phrases_key) REFERENCES phrases (key) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "phrases_translations_phrases_key_foreign" ON "public"."phrases_translations" IS NULL;
 
@@ -588,19 +686,25 @@ DROP TABLE IF EXISTS "public"."collections_items";
 
 --- BEGIN SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
 
-DELETE FROM "public"."directus_fields" WHERE "id" = 684;
+DELETE
+FROM "public"."directus_fields"
+WHERE "id" = 684;
 
 --- END SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
 
 --- BEGIN SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
 
-DELETE FROM "public"."directus_collections" WHERE "collection" = 'collections_items';
+DELETE
+FROM "public"."directus_collections"
+WHERE "collection" = 'collections_items';
 
 --- END SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
 
 --- BEGIN SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
 
-UPDATE "public"."directus_relations" SET "one_field" = NULL WHERE "id" = 211;
+UPDATE "public"."directus_relations"
+SET "one_field" = NULL
+WHERE "id" = 211;
 
 --- END SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
 -- +goose Down
@@ -611,77 +715,89 @@ UPDATE "public"."directus_relations" SET "one_field" = NULL WHERE "id" = 211;
 
 --- BEGIN ALTER TABLE "public"."events_translations" ---
 
-ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_events_id_foreign";
+ALTER TABLE IF EXISTS "public"."events_translations"
+    DROP CONSTRAINT IF EXISTS "events_translations_events_id_foreign";
 
 DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
 
 ALTER TABLE IF EXISTS "public"."events_translations"
-	ALTER COLUMN "events_id" DROP NOT NULL;
+    ALTER COLUMN "events_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."events_translations"
+    DROP CONSTRAINT IF EXISTS "events_translations_languages_code_foreign";
 
 DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
 
 ALTER TABLE IF EXISTS "public"."events_translations"
-	ALTER COLUMN "languages_code" DROP NOT NULL,
-	ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+    ALTER COLUMN "languages_code" DROP NOT NULL,
+    ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
 
-ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_events_id_foreign" FOREIGN KEY (events_id) REFERENCES events(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."events_translations"
+    ADD CONSTRAINT "events_translations_events_id_foreign" FOREIGN KEY (events_id) REFERENCES events (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "events_translations_events_id_foreign" ON "public"."events_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."events_translations"
+    ADD CONSTRAINT "events_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "events_translations_languages_code_foreign" ON "public"."events_translations" IS NULL;
 
 CREATE INDEX events_translations_events_id_languages_code_index ON public.events_translations USING btree (events_id, languages_code);
 
-COMMENT ON INDEX "public"."events_translations_events_id_languages_code_index"  IS NULL;
+COMMENT ON INDEX "public"."events_translations_events_id_languages_code_index" IS NULL;
 
 --- END ALTER TABLE "public"."events_translations" ---
 
 --- BEGIN ALTER TABLE "public"."tags_translations" ---
 
-ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_tags_id_foreign";
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    DROP CONSTRAINT IF EXISTS "tags_translations_tags_id_foreign";
 
 DROP INDEX IF EXISTS tags_translations_languages_code_tags_id_uindex;
 
 ALTER TABLE IF EXISTS "public"."tags_translations"
-	ALTER COLUMN "tags_id" DROP NOT NULL;
+    ALTER COLUMN "tags_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    DROP CONSTRAINT IF EXISTS "tags_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    ADD CONSTRAINT "tags_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "tags_translations_languages_code_foreign" ON "public"."tags_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."tags_translations"
+    ADD CONSTRAINT "tags_translations_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "tags_translations_tags_id_foreign" ON "public"."tags_translations" IS NULL;
 
 CREATE UNIQUE INDEX tags_translations_languages_code_tags_id_uindex ON public.tags_translations USING btree (languages_code, tags_id);
 
-COMMENT ON INDEX "public"."tags_translations_languages_code_tags_id_uindex"  IS NULL;
+COMMENT ON INDEX "public"."tags_translations_languages_code_tags_id_uindex" IS NULL;
 
 --- END ALTER TABLE "public"."tags_translations" ---
 
 --- BEGIN ALTER TABLE "public"."shows_tags" ---
 
-ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_shows_id_foreign";
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    DROP CONSTRAINT IF EXISTS "shows_tags_shows_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."shows_tags"
-	ALTER COLUMN "shows_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_tags_id_foreign";
+    ALTER COLUMN "shows_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."shows_tags"
-	ALTER COLUMN "tags_id" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "shows_tags_tags_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_shows_id_foreign" FOREIGN KEY (shows_id) REFERENCES shows(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    ALTER COLUMN "tags_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    ADD CONSTRAINT "shows_tags_shows_id_foreign" FOREIGN KEY (shows_id) REFERENCES shows (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "shows_tags_shows_id_foreign" ON "public"."shows_tags" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."shows_tags"
+    ADD CONSTRAINT "shows_tags_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "shows_tags_tags_id_foreign" ON "public"."shows_tags" IS NULL;
 
@@ -690,30 +806,34 @@ COMMENT ON CONSTRAINT "shows_tags_tags_id_foreign" ON "public"."shows_tags" IS N
 --- BEGIN ALTER TABLE "public"."collections_entries" ---
 
 ALTER TABLE IF EXISTS "public"."collections_entries"
-	ALTER COLUMN "item" DROP NOT NULL;
+    ALTER COLUMN "item" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."collections_entries"
-	ALTER COLUMN "collection" DROP NOT NULL;
+    ALTER COLUMN "collection" DROP NOT NULL;
 
 --- END ALTER TABLE "public"."collections_entries" ---
 
 --- BEGIN ALTER TABLE "public"."messages_messagetemplates" ---
 
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messages_id_foreign";
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messages_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
-	ALTER COLUMN "messages_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messagetemplates_id_foreign";
+    ALTER COLUMN "messages_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
-	ALTER COLUMN "messagetemplates_id" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messagetemplates_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messages_id_foreign" FOREIGN KEY (messages_id) REFERENCES messages(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    ALTER COLUMN "messagetemplates_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    ADD CONSTRAINT "messages_messagetemplates_messages_id_foreign" FOREIGN KEY (messages_id) REFERENCES messages (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "messages_messagetemplates_messages_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+    ADD CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
 
@@ -721,21 +841,25 @@ COMMENT ON CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" ON
 
 --- BEGIN ALTER TABLE "public"."collections_translations" ---
 
-ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_collections_id_foreign";
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    DROP CONSTRAINT IF EXISTS "collections_translations_collections_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."collections_translations"
-	ALTER COLUMN "collections_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_languages_code_foreign";
+    ALTER COLUMN "collections_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."collections_translations"
-	ALTER COLUMN "languages_code" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "collections_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_collections_id_foreign" FOREIGN KEY (collections_id) REFERENCES collections(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    ALTER COLUMN "languages_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    ADD CONSTRAINT "collections_translations_collections_id_foreign" FOREIGN KEY (collections_id) REFERENCES collections (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "collections_translations_collections_id_foreign" ON "public"."collections_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."collections_translations"
+    ADD CONSTRAINT "collections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "collections_translations_languages_code_foreign" ON "public"."collections_translations" IS NULL;
 
@@ -743,43 +867,49 @@ COMMENT ON CONSTRAINT "collections_translations_languages_code_foreign" ON "publ
 
 --- BEGIN ALTER TABLE "public"."notificationtemplates_translations" ---
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_notific__402aa733_foreign";
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_notific__402aa733_foreign";
 
 DROP INDEX IF EXISTS notificationtemplates_translations_notificationtemplates_id_lan;
 
 ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
-	ALTER COLUMN "notificationtemplates_id" DROP NOT NULL;
+    ALTER COLUMN "notificationtemplates_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    ADD CONSTRAINT "notificationtemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "notificationtemplates_translations_languages_code_foreign" ON "public"."notificationtemplates_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" FOREIGN KEY (notificationtemplates_id) REFERENCES notificationtemplates(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+    ADD CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" FOREIGN KEY (notificationtemplates_id) REFERENCES notificationtemplates (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" ON "public"."notificationtemplates_translations" IS NULL;
 
 CREATE UNIQUE INDEX notificationtemplates_translations_notificationtemplates_id_lan ON public.notificationtemplates_translations USING btree (notificationtemplates_id, languages_code);
 
-COMMENT ON INDEX "public"."notificationtemplates_translations_notificationtemplates_id_lan"  IS NULL;
+COMMENT ON INDEX "public"."notificationtemplates_translations_notificationtemplates_id_lan" IS NULL;
 
 --- END ALTER TABLE "public"."notificationtemplates_translations" ---
 
 --- BEGIN ALTER TABLE "public"."lessons_relations" ---
 
-ALTER TABLE IF EXISTS "public"."lessons_relations" DROP CONSTRAINT IF EXISTS "lessons_relations_lessons_id_foreign";
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+    DROP CONSTRAINT IF EXISTS "lessons_relations_lessons_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."lessons_relations"
-	ALTER COLUMN "lessons_id" DROP NOT NULL;
+    ALTER COLUMN "lessons_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."lessons_relations"
-	ALTER COLUMN "item" DROP NOT NULL;
+    ALTER COLUMN "item" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."lessons_relations"
-	ALTER COLUMN "collection" DROP NOT NULL;
+    ALTER COLUMN "collection" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."lessons_relations" ADD CONSTRAINT "lessons_relations_lessons_id_foreign" FOREIGN KEY (lessons_id) REFERENCES lessons(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+    ADD CONSTRAINT "lessons_relations_lessons_id_foreign" FOREIGN KEY (lessons_id) REFERENCES lessons (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "lessons_relations_lessons_id_foreign" ON "public"."lessons_relations" IS NULL;
 
@@ -787,30 +917,36 @@ COMMENT ON CONSTRAINT "lessons_relations_lessons_id_foreign" ON "public"."lesson
 
 --- BEGIN ALTER TABLE "public"."achievements_images" ---
 
-ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_image_foreign";
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    DROP CONSTRAINT IF EXISTS "achievements_images_image_foreign";
 
 ALTER TABLE IF EXISTS "public"."achievements_images"
-	ALTER COLUMN "image" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_achievement_id_foreign";
+    ALTER COLUMN "image" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."achievements_images"
-	ALTER COLUMN "achievement_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_language_foreign";
+    DROP CONSTRAINT IF EXISTS "achievements_images_achievement_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."achievements_images"
-	ALTER COLUMN "language" DROP NOT NULL;
+    ALTER COLUMN "achievement_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_achievement_id_foreign" FOREIGN KEY (achievement_id) REFERENCES achievements(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    DROP CONSTRAINT IF EXISTS "achievements_images_language_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ALTER COLUMN "language" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ADD CONSTRAINT "achievements_images_achievement_id_foreign" FOREIGN KEY (achievement_id) REFERENCES achievements (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievements_images_achievement_id_foreign" ON "public"."achievements_images" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_image_foreign" FOREIGN KEY (image) REFERENCES directus_files(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ADD CONSTRAINT "achievements_images_image_foreign" FOREIGN KEY (image) REFERENCES directus_files (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "achievements_images_image_foreign" ON "public"."achievements_images" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_language_foreign" FOREIGN KEY (language) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."achievements_images"
+    ADD CONSTRAINT "achievements_images_language_foreign" FOREIGN KEY (language) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "achievements_images_language_foreign" ON "public"."achievements_images" IS NULL;
 
@@ -818,12 +954,14 @@ COMMENT ON CONSTRAINT "achievements_images_language_foreign" ON "public"."achiev
 
 --- BEGIN ALTER TABLE "public"."lessons_images" ---
 
-ALTER TABLE IF EXISTS "public"."lessons_images" DROP CONSTRAINT IF EXISTS "lessons_images_lesson_id_foreign";
+ALTER TABLE IF EXISTS "public"."lessons_images"
+    DROP CONSTRAINT IF EXISTS "lessons_images_lesson_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."lessons_images"
-	ALTER COLUMN "lesson_id" DROP NOT NULL;
+    ALTER COLUMN "lesson_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."lessons_images" ADD CONSTRAINT "lessons_images_lesson_id_foreign" FOREIGN KEY (lesson_id) REFERENCES lessons(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."lessons_images"
+    ADD CONSTRAINT "lessons_images_lesson_id_foreign" FOREIGN KEY (lesson_id) REFERENCES lessons (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "lessons_images_lesson_id_foreign" ON "public"."lessons_images" IS NULL;
 
@@ -831,15 +969,19 @@ COMMENT ON CONSTRAINT "lessons_images_lesson_id_foreign" ON "public"."lessons_im
 
 --- BEGIN ALTER TABLE "public"."achievements_translations" ---
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_achievements_id_foreign";
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    DROP CONSTRAINT IF EXISTS "achievements_translations_achievements_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_achievements_id_foreign" FOREIGN KEY (achievements_id) REFERENCES achievements(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    ADD CONSTRAINT "achievements_translations_achievements_id_foreign" FOREIGN KEY (achievements_id) REFERENCES achievements (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "achievements_translations_achievements_id_foreign" ON "public"."achievements_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    DROP CONSTRAINT IF EXISTS "achievements_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+ALTER TABLE IF EXISTS "public"."achievements_translations"
+    ADD CONSTRAINT "achievements_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code);
 
 COMMENT ON CONSTRAINT "achievements_translations_languages_code_foreign" ON "public"."achievements_translations" IS NULL;
 
@@ -847,21 +989,25 @@ COMMENT ON CONSTRAINT "achievements_translations_languages_code_foreign" ON "pub
 
 --- BEGIN ALTER TABLE "public"."targets_usergroups" ---
 
-ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_targets_id_foreign";
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    DROP CONSTRAINT IF EXISTS "targets_usergroups_targets_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."targets_usergroups"
-	ALTER COLUMN "targets_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_usergroups_code_foreign";
+    ALTER COLUMN "targets_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."targets_usergroups"
-	ALTER COLUMN "usergroups_code" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "targets_usergroups_usergroups_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    ALTER COLUMN "usergroups_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    ADD CONSTRAINT "targets_usergroups_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "targets_usergroups_targets_id_foreign" ON "public"."targets_usergroups" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+    ADD CONSTRAINT "targets_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "targets_usergroups_usergroups_code_foreign" ON "public"."targets_usergroups" IS NULL;
 
@@ -869,21 +1015,25 @@ COMMENT ON CONSTRAINT "targets_usergroups_usergroups_code_foreign" ON "public"."
 
 --- BEGIN ALTER TABLE "public"."notifications_targets" ---
 
-ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_notifications_id_foreign";
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    DROP CONSTRAINT IF EXISTS "notifications_targets_notifications_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."notifications_targets"
-	ALTER COLUMN "notifications_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_targets_id_foreign";
+    ALTER COLUMN "notifications_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."notifications_targets"
-	ALTER COLUMN "targets_id" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "notifications_targets_targets_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_notifications_id_foreign" FOREIGN KEY (notifications_id) REFERENCES notifications(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    ALTER COLUMN "targets_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    ADD CONSTRAINT "notifications_targets_notifications_id_foreign" FOREIGN KEY (notifications_id) REFERENCES notifications (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "notifications_targets_notifications_id_foreign" ON "public"."notifications_targets" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+    ADD CONSTRAINT "notifications_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "notifications_targets_targets_id_foreign" ON "public"."notifications_targets" IS NULL;
 
@@ -891,40 +1041,46 @@ COMMENT ON CONSTRAINT "notifications_targets_targets_id_foreign" ON "public"."no
 
 --- BEGIN ALTER TABLE "public"."prompts_translations" ---
 
-ALTER TABLE IF EXISTS "public"."prompts_translations" DROP CONSTRAINT IF EXISTS "prompts_translations_prompts_id_foreign";
+ALTER TABLE IF EXISTS "public"."prompts_translations"
+    DROP CONSTRAINT IF EXISTS "prompts_translations_prompts_id_foreign";
 
 DROP INDEX IF EXISTS prompts_translations_prompts_id_languages_code_uindex;
 
 ALTER TABLE IF EXISTS "public"."prompts_translations"
-	ALTER COLUMN "prompts_id" DROP NOT NULL;
+    ALTER COLUMN "prompts_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."prompts_translations" ADD CONSTRAINT "prompts_translations_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."prompts_translations"
+    ADD CONSTRAINT "prompts_translations_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "prompts_translations_prompts_id_foreign" ON "public"."prompts_translations" IS NULL;
 
 CREATE UNIQUE INDEX prompts_translations_prompts_id_languages_code_uindex ON public.prompts_translations USING btree (prompts_id, languages_code);
 
-COMMENT ON INDEX "public"."prompts_translations_prompts_id_languages_code_uindex"  IS NULL;
+COMMENT ON INDEX "public"."prompts_translations_prompts_id_languages_code_uindex" IS NULL;
 
 --- END ALTER TABLE "public"."prompts_translations" ---
 
 --- BEGIN ALTER TABLE "public"."prompts_targets" ---
 
-ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_prompts_id_foreign";
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    DROP CONSTRAINT IF EXISTS "prompts_targets_prompts_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."prompts_targets"
-	ALTER COLUMN "prompts_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_targets_id_foreign";
+    ALTER COLUMN "prompts_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."prompts_targets"
-	ALTER COLUMN "targets_id" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "prompts_targets_targets_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    ALTER COLUMN "targets_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    ADD CONSTRAINT "prompts_targets_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "prompts_targets_prompts_id_foreign" ON "public"."prompts_targets" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+    ADD CONSTRAINT "prompts_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "prompts_targets_targets_id_foreign" ON "public"."prompts_targets" IS NULL;
 
@@ -932,21 +1088,25 @@ COMMENT ON CONSTRAINT "prompts_targets_targets_id_foreign" ON "public"."prompts_
 
 --- BEGIN ALTER TABLE "public"."achievementconditions_studytopics" ---
 
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_achievem__2e3395b2_foreign";
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_achievem__2e3395b2_foreign";
 
 ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
-	ALTER COLUMN "achievementconditions_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_studytopics_id_foreign";
+    ALTER COLUMN "achievementconditions_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
-	ALTER COLUMN "studytopics_id" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_studytopics_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" FOREIGN KEY (achievementconditions_id) REFERENCES achievementconditions(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    ALTER COLUMN "studytopics_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    ADD CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" FOREIGN KEY (achievementconditions_id) REFERENCES achievementconditions (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" FOREIGN KEY (studytopics_id) REFERENCES studytopics(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+    ADD CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" FOREIGN KEY (studytopics_id) REFERENCES studytopics (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
 
@@ -954,21 +1114,25 @@ COMMENT ON CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign"
 
 --- BEGIN ALTER TABLE "public"."faqs_usergroups" ---
 
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_faqs_id_foreign";
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    DROP CONSTRAINT IF EXISTS "faqs_usergroups_faqs_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."faqs_usergroups"
-	ALTER COLUMN "faqs_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_usergroups_code_foreign";
+    ALTER COLUMN "faqs_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."faqs_usergroups"
-	ALTER COLUMN "usergroups_code" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "faqs_usergroups_usergroups_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_faqs_id_foreign" FOREIGN KEY (faqs_id) REFERENCES faqs(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    ALTER COLUMN "usergroups_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    ADD CONSTRAINT "faqs_usergroups_faqs_id_foreign" FOREIGN KEY (faqs_id) REFERENCES faqs (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "faqs_usergroups_faqs_id_foreign" ON "public"."faqs_usergroups" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+    ADD CONSTRAINT "faqs_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "faqs_usergroups_usergroups_code_foreign" ON "public"."faqs_usergroups" IS NULL;
 
@@ -976,22 +1140,26 @@ COMMENT ON CONSTRAINT "faqs_usergroups_usergroups_code_foreign" ON "public"."faq
 
 --- BEGIN ALTER TABLE "public"."assetstreams_audio_languages" ---
 
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_assetstreams_id_foreign";
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_assetstreams_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
-	ALTER COLUMN "assetstreams_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_languages_code_foreign";
+    ALTER COLUMN "assetstreams_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
-	ALTER COLUMN "languages_code" DROP NOT NULL,
-	ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+    DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    ALTER COLUMN "languages_code" DROP NOT NULL,
+    ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    ADD CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+    ADD CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code);
 
 COMMENT ON CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
 
@@ -999,29 +1167,30 @@ COMMENT ON CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" ON "
 
 --- BEGIN CREATE TABLE "public"."collections_items" ---
 
-CREATE TABLE IF NOT EXISTS "public"."collections_items" (
-	"collection_id" int4 NULL  ,
-	"date_created" timestamptz NULL  ,
-	"date_updated" timestamptz NULL  ,
-	"episode_id" int4 NULL  ,
-	"id" int4 NOT NULL DEFAULT nextval('collections_items_id_seq'::regclass) ,
-	"page_id" int4 NULL  ,
-	"season_id" int4 NULL  ,
-	"show_id" int4 NULL  ,
-	"sort" int4 NULL  ,
-	"type" varchar(255) NULL DEFAULT NULL::character varying ,
-	"user_created" uuid NULL  ,
-	"user_updated" uuid NULL  ,
-	"link_id" int4 NULL  ,
-	CONSTRAINT "collections_items_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE ,
-	CONSTRAINT "collections_items_episode_id_foreign" FOREIGN KEY (episode_id) REFERENCES episodes(id) ON DELETE SET NULL ,
-	CONSTRAINT "collections_items_link_id_foreign" FOREIGN KEY (link_id) REFERENCES links(id) ON DELETE SET NULL ,
-	CONSTRAINT "collections_items_page_id_foreign" FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE SET NULL ,
-	CONSTRAINT "collections_items_pkey" PRIMARY KEY (id) ,
-	CONSTRAINT "collections_items_season_id_foreign" FOREIGN KEY (season_id) REFERENCES seasons(id) ON DELETE SET NULL ,
-	CONSTRAINT "collections_items_show_id_foreign" FOREIGN KEY (show_id) REFERENCES shows(id) ON DELETE SET NULL ,
-	CONSTRAINT "collections_items_user_created_foreign" FOREIGN KEY (user_created) REFERENCES directus_users(id) ,
-	CONSTRAINT "collections_items_user_updated_foreign" FOREIGN KEY (user_updated) REFERENCES directus_users(id)
+CREATE TABLE IF NOT EXISTS "public"."collections_items"
+(
+    "collection_id" int4         NULL,
+    "date_created"  timestamptz  NULL,
+    "date_updated"  timestamptz  NULL,
+    "episode_id"    int4         NULL,
+    "id"            int4         NOT NULL DEFAULT nextval('collections_items_id_seq'::regclass),
+    "page_id"       int4         NULL,
+    "season_id"     int4         NULL,
+    "show_id"       int4         NULL,
+    "sort"          int4         NULL,
+    "type"          varchar(255) NULL     DEFAULT NULL::character varying,
+    "user_created"  uuid         NULL,
+    "user_updated"  uuid         NULL,
+    "link_id"       int4         NULL,
+    CONSTRAINT "collections_items_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections (id) ON DELETE CASCADE,
+    CONSTRAINT "collections_items_episode_id_foreign" FOREIGN KEY (episode_id) REFERENCES episodes (id) ON DELETE SET NULL,
+    CONSTRAINT "collections_items_link_id_foreign" FOREIGN KEY (link_id) REFERENCES links (id) ON DELETE SET NULL,
+    CONSTRAINT "collections_items_page_id_foreign" FOREIGN KEY (page_id) REFERENCES pages (id) ON DELETE SET NULL,
+    CONSTRAINT "collections_items_pkey" PRIMARY KEY (id),
+    CONSTRAINT "collections_items_season_id_foreign" FOREIGN KEY (season_id) REFERENCES seasons (id) ON DELETE SET NULL,
+    CONSTRAINT "collections_items_show_id_foreign" FOREIGN KEY (show_id) REFERENCES shows (id) ON DELETE SET NULL,
+    CONSTRAINT "collections_items_user_created_foreign" FOREIGN KEY (user_created) REFERENCES directus_users (id),
+    CONSTRAINT "collections_items_user_updated_foreign" FOREIGN KEY (user_updated) REFERENCES directus_users (id)
 );
 
 GRANT SELECT ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
@@ -1033,43 +1202,43 @@ GRANT REFERENCES ON TABLE "public"."collections_items" TO directus; --WARN: Gran
 GRANT TRIGGER ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
 GRANT SELECT ON TABLE "public"."collections_items" TO api; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
 
-COMMENT ON COLUMN "public"."collections_items"."collection_id"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."collection_id" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."date_created"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."date_created" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."date_updated"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."date_updated" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."episode_id"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."episode_id" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."id"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."id" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."page_id"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."page_id" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."season_id"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."season_id" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."show_id"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."show_id" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."sort"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."sort" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."type"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."type" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."user_created"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."user_created" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."user_updated"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."user_updated" IS NULL;
 
 
-COMMENT ON COLUMN "public"."collections_items"."link_id"  IS NULL;
+COMMENT ON COLUMN "public"."collections_items"."link_id" IS NULL;
 
 COMMENT ON CONSTRAINT "collections_items_collection_id_foreign" ON "public"."collections_items" IS NULL;
 
@@ -1097,28 +1266,32 @@ COMMENT ON CONSTRAINT "collections_items_user_created_foreign" ON "public"."coll
 
 COMMENT ON CONSTRAINT "collections_items_user_updated_foreign" ON "public"."collections_items" IS NULL;
 
-COMMENT ON TABLE "public"."collections_items"  IS NULL;
+COMMENT ON TABLE "public"."collections_items" IS NULL;
 
 --- END CREATE TABLE "public"."collections_items" ---
 
 --- BEGIN ALTER TABLE "public"."assetstreams_subtitle_languages" ---
 
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_assetstreams_id_foreign";
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_assetstreams_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
-	ALTER COLUMN "assetstreams_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_languages_code_foreign";
+    ALTER COLUMN "assetstreams_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
-	ALTER COLUMN "languages_code" DROP NOT NULL,
-	ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+    DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    ALTER COLUMN "languages_code" DROP NOT NULL,
+    ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    ADD CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+    ADD CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code);
 
 COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
 
@@ -1126,21 +1299,25 @@ COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" O
 
 --- BEGIN ALTER TABLE "public"."applicationgroups_usergroups" ---
 
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_applicationgroups_id_foreign";
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_applicationgroups_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
-	ALTER COLUMN "applicationgroups_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_usergroups_code_foreign";
+    ALTER COLUMN "applicationgroups_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
-	ALTER COLUMN "usergroups_code" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_usergroups_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" FOREIGN KEY (applicationgroups_id) REFERENCES applicationgroups(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    ALTER COLUMN "usergroups_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    ADD CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" FOREIGN KEY (applicationgroups_id) REFERENCES applicationgroups (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+    ADD CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups (code) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
 
@@ -1148,21 +1325,25 @@ COMMENT ON CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" ON 
 
 --- BEGIN ALTER TABLE "public"."games_styledimages" ---
 
-ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_games_id_foreign";
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    DROP CONSTRAINT IF EXISTS "games_styledimages_games_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."games_styledimages"
-	ALTER COLUMN "games_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_styledimages_id_foreign";
+    ALTER COLUMN "games_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."games_styledimages"
-	ALTER COLUMN "styledimages_id" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "games_styledimages_styledimages_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_games_id_foreign" FOREIGN KEY (games_id) REFERENCES games(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    ALTER COLUMN "styledimages_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    ADD CONSTRAINT "games_styledimages_games_id_foreign" FOREIGN KEY (games_id) REFERENCES games (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "games_styledimages_games_id_foreign" ON "public"."games_styledimages" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_styledimages_id_foreign" FOREIGN KEY (styledimages_id) REFERENCES styledimages(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+    ADD CONSTRAINT "games_styledimages_styledimages_id_foreign" FOREIGN KEY (styledimages_id) REFERENCES styledimages (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "games_styledimages_styledimages_id_foreign" ON "public"."games_styledimages" IS NULL;
 
@@ -1170,12 +1351,14 @@ COMMENT ON CONSTRAINT "games_styledimages_styledimages_id_foreign" ON "public"."
 
 --- BEGIN ALTER TABLE "public"."timedmetadata_translations" ---
 
-ALTER TABLE IF EXISTS "public"."timedmetadata_translations" DROP CONSTRAINT IF EXISTS "timedmetadata_translations_timedmetadata_id_foreign";
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
+    DROP CONSTRAINT IF EXISTS "timedmetadata_translations_timedmetadata_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
-	ALTER COLUMN "timedmetadata_id" DROP NOT NULL;
+    ALTER COLUMN "timedmetadata_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."timedmetadata_translations" ADD CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" FOREIGN KEY (timedmetadata_id) REFERENCES timedmetadata(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
+    ADD CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" FOREIGN KEY (timedmetadata_id) REFERENCES timedmetadata (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" ON "public"."timedmetadata_translations" IS NULL;
 
@@ -1183,12 +1366,14 @@ COMMENT ON CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" ON "
 
 --- BEGIN ALTER TABLE "public"."calendarentries_translations" ---
 
-ALTER TABLE IF EXISTS "public"."calendarentries_translations" DROP CONSTRAINT IF EXISTS "calendarentries_translations_calendarentries_id_foreign";
+ALTER TABLE IF EXISTS "public"."calendarentries_translations"
+    DROP CONSTRAINT IF EXISTS "calendarentries_translations_calendarentries_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."calendarentries_translations"
-	ALTER COLUMN "calendarentries_id" DROP NOT NULL;
+    ALTER COLUMN "calendarentries_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."calendarentries_translations" ADD CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" FOREIGN KEY (calendarentries_id) REFERENCES calendarentries(id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS "public"."calendarentries_translations"
+    ADD CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" FOREIGN KEY (calendarentries_id) REFERENCES calendarentries (id) ON DELETE CASCADE;
 
 COMMENT ON CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" ON "public"."calendarentries_translations" IS NULL;
 
@@ -1196,46 +1381,54 @@ COMMENT ON CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" 
 
 --- BEGIN ALTER TABLE "public"."messagetemplates_translations" ---
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_messagetemplates_id_foreign";
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    DROP CONSTRAINT IF EXISTS "messagetemplates_translations_messagetemplates_id_foreign";
 
 DROP INDEX IF EXISTS messagetemplates_translations_messagetemplates_id_languages_cod;
 
 ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
-	ALTER COLUMN "messagetemplates_id" DROP NOT NULL;
+    ALTER COLUMN "messagetemplates_id" DROP NOT NULL;
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    DROP CONSTRAINT IF EXISTS "messagetemplates_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    ADD CONSTRAINT "messagetemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "messagetemplates_translations_languages_code_foreign" ON "public"."messagetemplates_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+    ADD CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" ON "public"."messagetemplates_translations" IS NULL;
 
 CREATE UNIQUE INDEX messagetemplates_translations_messagetemplates_id_languages_cod ON public.messagetemplates_translations USING btree (messagetemplates_id, languages_code);
 
-COMMENT ON INDEX "public"."messagetemplates_translations_messagetemplates_id_languages_cod"  IS NULL;
+COMMENT ON INDEX "public"."messagetemplates_translations_messagetemplates_id_languages_cod" IS NULL;
 
 --- END ALTER TABLE "public"."messagetemplates_translations" ---
 
 --- BEGIN ALTER TABLE "public"."songcollections_translations" ---
 
-ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_songcollections_id_foreign";
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    DROP CONSTRAINT IF EXISTS "songcollections_translations_songcollections_id_foreign";
 
 ALTER TABLE IF EXISTS "public"."songcollections_translations"
-	ALTER COLUMN "songcollections_id" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_languages_code_foreign";
+    ALTER COLUMN "songcollections_id" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."songcollections_translations"
-	ALTER COLUMN "languages_code" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "songcollections_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    ALTER COLUMN "languages_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    ADD CONSTRAINT "songcollections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "songcollections_translations_languages_code_foreign" ON "public"."songcollections_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_songcollections_id_foreign" FOREIGN KEY (songcollections_id) REFERENCES songcollections(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+    ADD CONSTRAINT "songcollections_translations_songcollections_id_foreign" FOREIGN KEY (songcollections_id) REFERENCES songcollections (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "songcollections_translations_songcollections_id_foreign" ON "public"."songcollections_translations" IS NULL;
 
@@ -1243,21 +1436,25 @@ COMMENT ON CONSTRAINT "songcollections_translations_songcollections_id_foreign" 
 
 --- BEGIN ALTER TABLE "public"."phrases_translations" ---
 
-ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_phrases_key_foreign";
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    DROP CONSTRAINT IF EXISTS "phrases_translations_phrases_key_foreign";
 
 ALTER TABLE IF EXISTS "public"."phrases_translations"
-	ALTER COLUMN "phrases_key" DROP NOT NULL;
-
-ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_languages_code_foreign";
+    ALTER COLUMN "phrases_key" DROP NOT NULL;
 
 ALTER TABLE IF EXISTS "public"."phrases_translations"
-	ALTER COLUMN "languages_code" DROP NOT NULL;
+    DROP CONSTRAINT IF EXISTS "phrases_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    ALTER COLUMN "languages_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    ADD CONSTRAINT "phrases_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "phrases_translations_languages_code_foreign" ON "public"."phrases_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_phrases_key_foreign" FOREIGN KEY (phrases_key) REFERENCES phrases(key) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+    ADD CONSTRAINT "phrases_translations_phrases_key_foreign" FOREIGN KEY (phrases_key) REFERENCES phrases (key) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "phrases_translations_phrases_key_foreign" ON "public"."phrases_translations" IS NULL;
 
@@ -1265,9 +1462,11 @@ COMMENT ON CONSTRAINT "phrases_translations_phrases_key_foreign" ON "public"."ph
 
 --- BEGIN ALTER TABLE "public"."playlists" ---
 
-ALTER TABLE IF EXISTS "public"."playlists" DROP CONSTRAINT IF EXISTS "playlists_collection_id_foreign";
+ALTER TABLE IF EXISTS "public"."playlists"
+    DROP CONSTRAINT IF EXISTS "playlists_collection_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."playlists" ADD CONSTRAINT "playlists_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."playlists"
+    ADD CONSTRAINT "playlists_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "playlists_collection_id_foreign" ON "public"."playlists" IS NULL;
 
@@ -1275,15 +1474,19 @@ COMMENT ON CONSTRAINT "playlists_collection_id_foreign" ON "public"."playlists" 
 
 --- BEGIN ALTER TABLE "public"."playlists_translations" ---
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_languages_code_foreign";
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    DROP CONSTRAINT IF EXISTS "playlists_translations_languages_code_foreign";
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    ADD CONSTRAINT "playlists_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages (code) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "playlists_translations_languages_code_foreign" ON "public"."playlists_translations" IS NULL;
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_playlists_id_foreign";
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    DROP CONSTRAINT IF EXISTS "playlists_translations_playlists_id_foreign";
 
-ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_playlists_id_foreign" FOREIGN KEY (playlists_id) REFERENCES playlists(id) ON DELETE SET NULL;
+ALTER TABLE IF EXISTS "public"."playlists_translations"
+    ADD CONSTRAINT "playlists_translations_playlists_id_foreign" FOREIGN KEY (playlists_id) REFERENCES playlists (id) ON DELETE SET NULL;
 
 COMMENT ON CONSTRAINT "playlists_translations_playlists_id_foreign" ON "public"."playlists_translations" IS NULL;
 
@@ -1291,18 +1494,66 @@ COMMENT ON CONSTRAINT "playlists_translations_playlists_id_foreign" ON "public".
 
 --- BEGIN SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
 
-INSERT INTO "public"."directus_collections" ("collection", "icon", "note", "display_template", "hidden", "singleton", "translations", "archive_field", "archive_app_filter", "archive_value", "unarchive_value", "sort_field", "accountability", "color", "item_duplication_fields", "sort", "group", "collapse", "preview_url", "versioning")  VALUES ('collections_items', NULL, NULL, '{{page_id.translations}}{{show_id.translations}}{{season_id.translations}}{{episode_id.translations}}', true, false, NULL, NULL, true, NULL, NULL, 'sort', 'all', NULL, NULL, 2, 'collections', 'open', NULL, false);
+INSERT INTO "public"."directus_collections" ("collection", "icon", "note", "display_template", "hidden", "singleton",
+                                             "translations", "archive_field", "archive_app_filter", "archive_value",
+                                             "unarchive_value", "sort_field", "accountability", "color",
+                                             "item_duplication_fields", "sort", "group", "collapse", "preview_url",
+                                             "versioning")
+VALUES ('collections_items', NULL, NULL,
+        '{{page_id.translations}}{{show_id.translations}}{{season_id.translations}}{{episode_id.translations}}', true,
+        false, NULL, NULL, true, NULL, NULL, 'sort', 'all', NULL, NULL, 2, 'collections', 'open', NULL, false);
 
 --- END SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
 
 --- BEGIN SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
 
-INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display", "display_options", "readonly", "hidden", "sort", "width", "translations", "note", "conditions", "required", "group", "validation", "validation_message")  VALUES (684, 'collections', 'collections_items', 'o2m', 'list-o2m', '{"limit":100,"fields":["type","page_id.translations","show_id.translations","season_id.translations","episode_id.translations","link_id.translations"],"enableSearchFilter":true,"template":null,"enableLink":true,"enableSelect":false}', 'related-values', NULL, false, true, 3, 'full', NULL, NULL, '[{"name":"Hidden if not Select","rule":{"_and":[{"filter_type":{"_neq":"select"}}]},"hidden":true,"options":{"layout":"list","enableCreate":true,"enableSelect":true,"limit":15,"enableSearchFilter":false,"enableLink":false}}]', false, 'config', NULL, NULL);
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (684, 'collections', 'collections_items', 'o2m', 'list-o2m', '{
+  "limit": 100,
+  "fields": [
+    "type",
+    "page_id.translations",
+    "show_id.translations",
+    "season_id.translations",
+    "episode_id.translations",
+    "link_id.translations"
+  ],
+  "enableSearchFilter": true,
+  "template": null,
+  "enableLink": true,
+  "enableSelect": false
+}', 'related-values', NULL, false, true, 3, 'full', NULL, NULL, '[
+  {
+    "name": "Hidden if not Select",
+    "rule": {
+      "_and": [
+        {
+          "filter_type": {
+            "_neq": "select"
+          }
+        }
+      ]
+    },
+    "hidden": true,
+    "options": {
+      "layout": "list",
+      "enableCreate": true,
+      "enableSelect": true,
+      "limit": 15,
+      "enableSearchFilter": false,
+      "enableLink": false
+    }
+  }
+]', false, 'config', NULL, NULL);
 
 --- END SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
 
 --- BEGIN SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
 
-UPDATE "public"."directus_relations" SET "one_field" = 'collections_items' WHERE "id" = 211;
+UPDATE "public"."directus_relations"
+SET "one_field" = 'collections_items'
+WHERE "id" = 211;
 
 --- END SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---

--- a/migrations/00236_fix_indexes.sql
+++ b/migrations/00236_fix_indexes.sql
@@ -1,0 +1,1308 @@
+-- +goose Up
+/***********************************************************/
+/*** SCRIPT AUTHOR: Fredrik Vedvik (fredrik@vedvik.tech) ***/
+/***    CREATED ON: 2023-11-07T14:36:46.806Z             ***/
+/***********************************************************/
+
+--- BEGIN ALTER TABLE "public"."tags_translations" ---
+
+ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_tags_id_foreign";
+
+DROP INDEX IF EXISTS tags_translations_languages_code_tags_id_uindex;
+
+ALTER TABLE IF EXISTS "public"."tags_translations"
+	ALTER COLUMN "tags_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "tags_translations_tags_id_foreign" ON "public"."tags_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "tags_translations_languages_code_foreign" ON "public"."tags_translations" IS NULL;
+
+CREATE UNIQUE INDEX tags_translations_languages_code_tags_id_uindex ON public.tags_translations USING btree (languages_code, tags_id);
+
+COMMENT ON INDEX "public"."tags_translations_languages_code_tags_id_uindex"  IS NULL;
+
+--- END ALTER TABLE "public"."tags_translations" ---
+
+--- BEGIN ALTER TABLE "public"."playlists" ---
+
+ALTER TABLE IF EXISTS "public"."playlists" DROP CONSTRAINT IF EXISTS "playlists_collection_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."playlists" ADD CONSTRAINT "playlists_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE RESTRICT;
+
+COMMENT ON CONSTRAINT "playlists_collection_id_foreign" ON "public"."playlists" IS NULL;
+
+--- END ALTER TABLE "public"."playlists" ---
+
+--- BEGIN ALTER TABLE "public"."playlists_translations" ---
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "playlists_translations_languages_code_foreign" ON "public"."playlists_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_playlists_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_playlists_id_foreign" FOREIGN KEY (playlists_id) REFERENCES playlists(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "playlists_translations_playlists_id_foreign" ON "public"."playlists_translations" IS NULL;
+
+--- END ALTER TABLE "public"."playlists_translations" ---
+
+--- BEGIN ALTER TABLE "public"."events_translations" ---
+
+ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_events_id_foreign";
+
+DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
+
+ALTER TABLE IF EXISTS "public"."events_translations"
+	ALTER COLUMN "events_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_languages_code_foreign";
+
+DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
+
+ALTER TABLE IF EXISTS "public"."events_translations"
+	ALTER COLUMN "languages_code" SET NOT NULL,
+	ALTER COLUMN "languages_code" DROP DEFAULT ;
+
+ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_events_id_foreign" FOREIGN KEY (events_id) REFERENCES events(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "events_translations_events_id_foreign" ON "public"."events_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "events_translations_languages_code_foreign" ON "public"."events_translations" IS NULL;
+
+CREATE INDEX events_translations_events_id_languages_code_index ON public.events_translations USING btree (events_id, languages_code);
+
+COMMENT ON INDEX "public"."events_translations_events_id_languages_code_index"  IS NULL;
+
+--- END ALTER TABLE "public"."events_translations" ---
+
+--- BEGIN ALTER TABLE "public"."shows_tags" ---
+
+ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_shows_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."shows_tags"
+	ALTER COLUMN "shows_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_tags_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."shows_tags"
+	ALTER COLUMN "tags_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "shows_tags_tags_id_foreign" ON "public"."shows_tags" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_shows_id_foreign" FOREIGN KEY (shows_id) REFERENCES shows(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "shows_tags_shows_id_foreign" ON "public"."shows_tags" IS NULL;
+
+--- END ALTER TABLE "public"."shows_tags" ---
+
+--- BEGIN ALTER TABLE "public"."collections_entries" ---
+
+ALTER TABLE IF EXISTS "public"."collections_entries"
+	ALTER COLUMN "item" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_entries"
+	ALTER COLUMN "collection" SET NOT NULL;
+
+--- END ALTER TABLE "public"."collections_entries" ---
+
+--- BEGIN ALTER TABLE "public"."messages_messagetemplates" ---
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messages_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+	ALTER COLUMN "messages_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messagetemplates_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+	ALTER COLUMN "messagetemplates_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messages_id_foreign" FOREIGN KEY (messages_id) REFERENCES messages(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "messages_messagetemplates_messages_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
+
+--- END ALTER TABLE "public"."messages_messagetemplates" ---
+
+--- BEGIN ALTER TABLE "public"."collections_translations" ---
+
+ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_collections_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."collections_translations"
+	ALTER COLUMN "collections_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."collections_translations"
+	ALTER COLUMN "languages_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_collections_id_foreign" FOREIGN KEY (collections_id) REFERENCES collections(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "collections_translations_collections_id_foreign" ON "public"."collections_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "collections_translations_languages_code_foreign" ON "public"."collections_translations" IS NULL;
+
+--- END ALTER TABLE "public"."collections_translations" ---
+
+--- BEGIN ALTER TABLE "public"."notificationtemplates_translations" ---
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_notific__402aa733_foreign";
+
+DROP INDEX IF EXISTS notificationtemplates_translations_notificationtemplates_id_lan;
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+	ALTER COLUMN "notificationtemplates_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "notificationtemplates_translations_languages_code_foreign" ON "public"."notificationtemplates_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" FOREIGN KEY (notificationtemplates_id) REFERENCES notificationtemplates(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" ON "public"."notificationtemplates_translations" IS NULL;
+
+CREATE UNIQUE INDEX notificationtemplates_translations_notificationtemplates_id_lan ON public.notificationtemplates_translations USING btree (notificationtemplates_id, languages_code);
+
+COMMENT ON INDEX "public"."notificationtemplates_translations_notificationtemplates_id_lan"  IS NULL;
+
+--- END ALTER TABLE "public"."notificationtemplates_translations" ---
+
+--- BEGIN ALTER TABLE "public"."lessons_relations" ---
+
+ALTER TABLE IF EXISTS "public"."lessons_relations" DROP CONSTRAINT IF EXISTS "lessons_relations_lessons_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+	ALTER COLUMN "lessons_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+	ALTER COLUMN "item" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+	ALTER COLUMN "collection" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_relations" ADD CONSTRAINT "lessons_relations_lessons_id_foreign" FOREIGN KEY (lessons_id) REFERENCES lessons(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "lessons_relations_lessons_id_foreign" ON "public"."lessons_relations" IS NULL;
+
+--- END ALTER TABLE "public"."lessons_relations" ---
+
+--- BEGIN ALTER TABLE "public"."achievements_images" ---
+
+ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_image_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+	ALTER COLUMN "image" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_achievement_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+	ALTER COLUMN "achievement_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_language_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+	ALTER COLUMN "language" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_language_foreign" FOREIGN KEY (language) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievements_images_language_foreign" ON "public"."achievements_images" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_image_foreign" FOREIGN KEY (image) REFERENCES directus_files(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievements_images_image_foreign" ON "public"."achievements_images" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_achievement_id_foreign" FOREIGN KEY (achievement_id) REFERENCES achievements(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievements_images_achievement_id_foreign" ON "public"."achievements_images" IS NULL;
+
+--- END ALTER TABLE "public"."achievements_images" ---
+
+--- BEGIN ALTER TABLE "public"."lessons_images" ---
+
+ALTER TABLE IF EXISTS "public"."lessons_images" DROP CONSTRAINT IF EXISTS "lessons_images_lesson_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."lessons_images"
+	ALTER COLUMN "lesson_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_images" ADD CONSTRAINT "lessons_images_lesson_id_foreign" FOREIGN KEY (lesson_id) REFERENCES lessons(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "lessons_images_lesson_id_foreign" ON "public"."lessons_images" IS NULL;
+
+--- END ALTER TABLE "public"."lessons_images" ---
+
+--- BEGIN ALTER TABLE "public"."achievements_translations" ---
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_achievements_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_achievements_id_foreign" FOREIGN KEY (achievements_id) REFERENCES achievements(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievements_translations_achievements_id_foreign" ON "public"."achievements_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievements_translations_languages_code_foreign" ON "public"."achievements_translations" IS NULL;
+
+--- END ALTER TABLE "public"."achievements_translations" ---
+
+--- BEGIN ALTER TABLE "public"."targets_usergroups" ---
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_targets_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+	ALTER COLUMN "targets_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_usergroups_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+	ALTER COLUMN "usergroups_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "targets_usergroups_usergroups_code_foreign" ON "public"."targets_usergroups" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "targets_usergroups_targets_id_foreign" ON "public"."targets_usergroups" IS NULL;
+
+--- END ALTER TABLE "public"."targets_usergroups" ---
+
+--- BEGIN ALTER TABLE "public"."notifications_targets" ---
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_notifications_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+	ALTER COLUMN "notifications_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_targets_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+	ALTER COLUMN "targets_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "notifications_targets_targets_id_foreign" ON "public"."notifications_targets" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_notifications_id_foreign" FOREIGN KEY (notifications_id) REFERENCES notifications(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "notifications_targets_notifications_id_foreign" ON "public"."notifications_targets" IS NULL;
+
+--- END ALTER TABLE "public"."notifications_targets" ---
+
+--- BEGIN ALTER TABLE "public"."prompts_translations" ---
+
+ALTER TABLE IF EXISTS "public"."prompts_translations" DROP CONSTRAINT IF EXISTS "prompts_translations_prompts_id_foreign";
+
+DROP INDEX IF EXISTS prompts_translations_prompts_id_languages_code_uindex;
+
+ALTER TABLE IF EXISTS "public"."prompts_translations"
+	ALTER COLUMN "prompts_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_translations" ADD CONSTRAINT "prompts_translations_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "prompts_translations_prompts_id_foreign" ON "public"."prompts_translations" IS NULL;
+
+CREATE UNIQUE INDEX prompts_translations_prompts_id_languages_code_uindex ON public.prompts_translations USING btree (prompts_id, languages_code);
+
+COMMENT ON INDEX "public"."prompts_translations_prompts_id_languages_code_uindex"  IS NULL;
+
+--- END ALTER TABLE "public"."prompts_translations" ---
+
+--- BEGIN ALTER TABLE "public"."prompts_targets" ---
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_prompts_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+	ALTER COLUMN "prompts_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_targets_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+	ALTER COLUMN "targets_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "prompts_targets_prompts_id_foreign" ON "public"."prompts_targets" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "prompts_targets_targets_id_foreign" ON "public"."prompts_targets" IS NULL;
+
+--- END ALTER TABLE "public"."prompts_targets" ---
+
+--- BEGIN ALTER TABLE "public"."achievementconditions_studytopics" ---
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_achievem__2e3395b2_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+	ALTER COLUMN "achievementconditions_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_studytopics_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+	ALTER COLUMN "studytopics_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" FOREIGN KEY (studytopics_id) REFERENCES studytopics(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" FOREIGN KEY (achievementconditions_id) REFERENCES achievementconditions(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
+
+--- END ALTER TABLE "public"."achievementconditions_studytopics" ---
+
+--- BEGIN ALTER TABLE "public"."faqs_usergroups" ---
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_faqs_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+	ALTER COLUMN "faqs_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_usergroups_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+	ALTER COLUMN "usergroups_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_faqs_id_foreign" FOREIGN KEY (faqs_id) REFERENCES faqs(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "faqs_usergroups_faqs_id_foreign" ON "public"."faqs_usergroups" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "faqs_usergroups_usergroups_code_foreign" ON "public"."faqs_usergroups" IS NULL;
+
+--- END ALTER TABLE "public"."faqs_usergroups" ---
+
+--- BEGIN ALTER TABLE "public"."assetstreams_audio_languages" ---
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_assetstreams_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+	ALTER COLUMN "assetstreams_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+	ALTER COLUMN "languages_code" SET NOT NULL,
+	ALTER COLUMN "languages_code" DROP DEFAULT ;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+
+COMMENT ON CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
+
+--- END ALTER TABLE "public"."assetstreams_audio_languages" ---
+
+--- BEGIN ALTER TABLE "public"."assetstreams_subtitle_languages" ---
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_assetstreams_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+	ALTER COLUMN "assetstreams_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+	ALTER COLUMN "languages_code" SET NOT NULL,
+	ALTER COLUMN "languages_code" DROP DEFAULT ;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+
+COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
+
+--- END ALTER TABLE "public"."assetstreams_subtitle_languages" ---
+
+--- BEGIN ALTER TABLE "public"."applicationgroups_usergroups" ---
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_applicationgroups_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+	ALTER COLUMN "applicationgroups_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_usergroups_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+	ALTER COLUMN "usergroups_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" FOREIGN KEY (applicationgroups_id) REFERENCES applicationgroups(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
+
+--- END ALTER TABLE "public"."applicationgroups_usergroups" ---
+
+--- BEGIN ALTER TABLE "public"."timedmetadata_translations" ---
+
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations" DROP CONSTRAINT IF EXISTS "timedmetadata_translations_timedmetadata_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
+	ALTER COLUMN "timedmetadata_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations" ADD CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" FOREIGN KEY (timedmetadata_id) REFERENCES timedmetadata(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" ON "public"."timedmetadata_translations" IS NULL;
+
+--- END ALTER TABLE "public"."timedmetadata_translations" ---
+
+--- BEGIN ALTER TABLE "public"."games_styledimages" ---
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_games_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+	ALTER COLUMN "games_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_styledimages_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+	ALTER COLUMN "styledimages_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_games_id_foreign" FOREIGN KEY (games_id) REFERENCES games(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "games_styledimages_games_id_foreign" ON "public"."games_styledimages" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_styledimages_id_foreign" FOREIGN KEY (styledimages_id) REFERENCES styledimages(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "games_styledimages_styledimages_id_foreign" ON "public"."games_styledimages" IS NULL;
+
+--- END ALTER TABLE "public"."games_styledimages" ---
+
+--- BEGIN ALTER TABLE "public"."calendarentries_translations" ---
+
+ALTER TABLE IF EXISTS "public"."calendarentries_translations" DROP CONSTRAINT IF EXISTS "calendarentries_translations_calendarentries_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."calendarentries_translations"
+	ALTER COLUMN "calendarentries_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."calendarentries_translations" ADD CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" FOREIGN KEY (calendarentries_id) REFERENCES calendarentries(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" ON "public"."calendarentries_translations" IS NULL;
+
+--- END ALTER TABLE "public"."calendarentries_translations" ---
+
+--- BEGIN ALTER TABLE "public"."messagetemplates_translations" ---
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_messagetemplates_id_foreign";
+
+DROP INDEX IF EXISTS messagetemplates_translations_messagetemplates_id_languages_cod;
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+	ALTER COLUMN "messagetemplates_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" ON "public"."messagetemplates_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "messagetemplates_translations_languages_code_foreign" ON "public"."messagetemplates_translations" IS NULL;
+
+CREATE UNIQUE INDEX messagetemplates_translations_messagetemplates_id_languages_cod ON public.messagetemplates_translations USING btree (messagetemplates_id, languages_code);
+
+COMMENT ON INDEX "public"."messagetemplates_translations_messagetemplates_id_languages_cod"  IS NULL;
+
+--- END ALTER TABLE "public"."messagetemplates_translations" ---
+
+--- BEGIN ALTER TABLE "public"."songcollections_translations" ---
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_songcollections_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+	ALTER COLUMN "songcollections_id" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+	ALTER COLUMN "languages_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "songcollections_translations_languages_code_foreign" ON "public"."songcollections_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_songcollections_id_foreign" FOREIGN KEY (songcollections_id) REFERENCES songcollections(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "songcollections_translations_songcollections_id_foreign" ON "public"."songcollections_translations" IS NULL;
+
+--- END ALTER TABLE "public"."songcollections_translations" ---
+
+--- BEGIN ALTER TABLE "public"."phrases_translations" ---
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_phrases_key_foreign";
+
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+	ALTER COLUMN "phrases_key" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+	ALTER COLUMN "languages_code" SET NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "phrases_translations_languages_code_foreign" ON "public"."phrases_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_phrases_key_foreign" FOREIGN KEY (phrases_key) REFERENCES phrases(key) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "phrases_translations_phrases_key_foreign" ON "public"."phrases_translations" IS NULL;
+
+--- END ALTER TABLE "public"."phrases_translations" ---
+
+--- BEGIN DROP TABLE "public"."collections_items" ---
+
+DROP TABLE IF EXISTS "public"."collections_items";
+
+--- END DROP TABLE "public"."collections_items" ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+DELETE FROM "public"."directus_fields" WHERE "id" = 684;
+
+--- END SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+DELETE FROM "public"."directus_collections" WHERE "collection" = 'collections_items';
+
+--- END SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
+
+UPDATE "public"."directus_relations" SET "one_field" = NULL WHERE "id" = 211;
+
+--- END SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
+-- +goose Down
+/***********************************************************/
+/*** SCRIPT AUTHOR: Fredrik Vedvik (fredrik@vedvik.tech) ***/
+/***    CREATED ON: 2023-11-07T14:36:48.573Z             ***/
+/***********************************************************/
+
+--- BEGIN ALTER TABLE "public"."events_translations" ---
+
+ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_events_id_foreign";
+
+DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
+
+ALTER TABLE IF EXISTS "public"."events_translations"
+	ALTER COLUMN "events_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."events_translations" DROP CONSTRAINT IF EXISTS "events_translations_languages_code_foreign";
+
+DROP INDEX IF EXISTS events_translations_events_id_languages_code_index;
+
+ALTER TABLE IF EXISTS "public"."events_translations"
+	ALTER COLUMN "languages_code" DROP NOT NULL,
+	ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+
+ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_events_id_foreign" FOREIGN KEY (events_id) REFERENCES events(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "events_translations_events_id_foreign" ON "public"."events_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."events_translations" ADD CONSTRAINT "events_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "events_translations_languages_code_foreign" ON "public"."events_translations" IS NULL;
+
+CREATE INDEX events_translations_events_id_languages_code_index ON public.events_translations USING btree (events_id, languages_code);
+
+COMMENT ON INDEX "public"."events_translations_events_id_languages_code_index"  IS NULL;
+
+--- END ALTER TABLE "public"."events_translations" ---
+
+--- BEGIN ALTER TABLE "public"."tags_translations" ---
+
+ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_tags_id_foreign";
+
+DROP INDEX IF EXISTS tags_translations_languages_code_tags_id_uindex;
+
+ALTER TABLE IF EXISTS "public"."tags_translations"
+	ALTER COLUMN "tags_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."tags_translations" DROP CONSTRAINT IF EXISTS "tags_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "tags_translations_languages_code_foreign" ON "public"."tags_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."tags_translations" ADD CONSTRAINT "tags_translations_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "tags_translations_tags_id_foreign" ON "public"."tags_translations" IS NULL;
+
+CREATE UNIQUE INDEX tags_translations_languages_code_tags_id_uindex ON public.tags_translations USING btree (languages_code, tags_id);
+
+COMMENT ON INDEX "public"."tags_translations_languages_code_tags_id_uindex"  IS NULL;
+
+--- END ALTER TABLE "public"."tags_translations" ---
+
+--- BEGIN ALTER TABLE "public"."shows_tags" ---
+
+ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_shows_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."shows_tags"
+	ALTER COLUMN "shows_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags" DROP CONSTRAINT IF EXISTS "shows_tags_tags_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."shows_tags"
+	ALTER COLUMN "tags_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_shows_id_foreign" FOREIGN KEY (shows_id) REFERENCES shows(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "shows_tags_shows_id_foreign" ON "public"."shows_tags" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."shows_tags" ADD CONSTRAINT "shows_tags_tags_id_foreign" FOREIGN KEY (tags_id) REFERENCES tags(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "shows_tags_tags_id_foreign" ON "public"."shows_tags" IS NULL;
+
+--- END ALTER TABLE "public"."shows_tags" ---
+
+--- BEGIN ALTER TABLE "public"."collections_entries" ---
+
+ALTER TABLE IF EXISTS "public"."collections_entries"
+	ALTER COLUMN "item" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_entries"
+	ALTER COLUMN "collection" DROP NOT NULL;
+
+--- END ALTER TABLE "public"."collections_entries" ---
+
+--- BEGIN ALTER TABLE "public"."messages_messagetemplates" ---
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messages_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+	ALTER COLUMN "messages_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" DROP CONSTRAINT IF EXISTS "messages_messagetemplates_messagetemplates_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates"
+	ALTER COLUMN "messagetemplates_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messages_id_foreign" FOREIGN KEY (messages_id) REFERENCES messages(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "messages_messagetemplates_messages_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."messages_messagetemplates" ADD CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "messages_messagetemplates_messagetemplates_id_foreign" ON "public"."messages_messagetemplates" IS NULL;
+
+--- END ALTER TABLE "public"."messages_messagetemplates" ---
+
+--- BEGIN ALTER TABLE "public"."collections_translations" ---
+
+ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_collections_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."collections_translations"
+	ALTER COLUMN "collections_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations" DROP CONSTRAINT IF EXISTS "collections_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."collections_translations"
+	ALTER COLUMN "languages_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_collections_id_foreign" FOREIGN KEY (collections_id) REFERENCES collections(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "collections_translations_collections_id_foreign" ON "public"."collections_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."collections_translations" ADD CONSTRAINT "collections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "collections_translations_languages_code_foreign" ON "public"."collections_translations" IS NULL;
+
+--- END ALTER TABLE "public"."collections_translations" ---
+
+--- BEGIN ALTER TABLE "public"."notificationtemplates_translations" ---
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_notific__402aa733_foreign";
+
+DROP INDEX IF EXISTS notificationtemplates_translations_notificationtemplates_id_lan;
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations"
+	ALTER COLUMN "notificationtemplates_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" DROP CONSTRAINT IF EXISTS "notificationtemplates_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "notificationtemplates_translations_languages_code_foreign" ON "public"."notificationtemplates_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."notificationtemplates_translations" ADD CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" FOREIGN KEY (notificationtemplates_id) REFERENCES notificationtemplates(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "notificationtemplates_translations_notific__402aa733_foreign" ON "public"."notificationtemplates_translations" IS NULL;
+
+CREATE UNIQUE INDEX notificationtemplates_translations_notificationtemplates_id_lan ON public.notificationtemplates_translations USING btree (notificationtemplates_id, languages_code);
+
+COMMENT ON INDEX "public"."notificationtemplates_translations_notificationtemplates_id_lan"  IS NULL;
+
+--- END ALTER TABLE "public"."notificationtemplates_translations" ---
+
+--- BEGIN ALTER TABLE "public"."lessons_relations" ---
+
+ALTER TABLE IF EXISTS "public"."lessons_relations" DROP CONSTRAINT IF EXISTS "lessons_relations_lessons_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+	ALTER COLUMN "lessons_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+	ALTER COLUMN "item" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_relations"
+	ALTER COLUMN "collection" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_relations" ADD CONSTRAINT "lessons_relations_lessons_id_foreign" FOREIGN KEY (lessons_id) REFERENCES lessons(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "lessons_relations_lessons_id_foreign" ON "public"."lessons_relations" IS NULL;
+
+--- END ALTER TABLE "public"."lessons_relations" ---
+
+--- BEGIN ALTER TABLE "public"."achievements_images" ---
+
+ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_image_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+	ALTER COLUMN "image" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_achievement_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+	ALTER COLUMN "achievement_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" DROP CONSTRAINT IF EXISTS "achievements_images_language_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_images"
+	ALTER COLUMN "language" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_achievement_id_foreign" FOREIGN KEY (achievement_id) REFERENCES achievements(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievements_images_achievement_id_foreign" ON "public"."achievements_images" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_image_foreign" FOREIGN KEY (image) REFERENCES directus_files(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "achievements_images_image_foreign" ON "public"."achievements_images" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_images" ADD CONSTRAINT "achievements_images_language_foreign" FOREIGN KEY (language) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "achievements_images_language_foreign" ON "public"."achievements_images" IS NULL;
+
+--- END ALTER TABLE "public"."achievements_images" ---
+
+--- BEGIN ALTER TABLE "public"."lessons_images" ---
+
+ALTER TABLE IF EXISTS "public"."lessons_images" DROP CONSTRAINT IF EXISTS "lessons_images_lesson_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."lessons_images"
+	ALTER COLUMN "lesson_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."lessons_images" ADD CONSTRAINT "lessons_images_lesson_id_foreign" FOREIGN KEY (lesson_id) REFERENCES lessons(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "lessons_images_lesson_id_foreign" ON "public"."lessons_images" IS NULL;
+
+--- END ALTER TABLE "public"."lessons_images" ---
+
+--- BEGIN ALTER TABLE "public"."achievements_translations" ---
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_achievements_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_achievements_id_foreign" FOREIGN KEY (achievements_id) REFERENCES achievements(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "achievements_translations_achievements_id_foreign" ON "public"."achievements_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" DROP CONSTRAINT IF EXISTS "achievements_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievements_translations" ADD CONSTRAINT "achievements_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+
+COMMENT ON CONSTRAINT "achievements_translations_languages_code_foreign" ON "public"."achievements_translations" IS NULL;
+
+--- END ALTER TABLE "public"."achievements_translations" ---
+
+--- BEGIN ALTER TABLE "public"."targets_usergroups" ---
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_targets_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+	ALTER COLUMN "targets_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" DROP CONSTRAINT IF EXISTS "targets_usergroups_usergroups_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups"
+	ALTER COLUMN "usergroups_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "targets_usergroups_targets_id_foreign" ON "public"."targets_usergroups" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."targets_usergroups" ADD CONSTRAINT "targets_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "targets_usergroups_usergroups_code_foreign" ON "public"."targets_usergroups" IS NULL;
+
+--- END ALTER TABLE "public"."targets_usergroups" ---
+
+--- BEGIN ALTER TABLE "public"."notifications_targets" ---
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_notifications_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+	ALTER COLUMN "notifications_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" DROP CONSTRAINT IF EXISTS "notifications_targets_targets_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."notifications_targets"
+	ALTER COLUMN "targets_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_notifications_id_foreign" FOREIGN KEY (notifications_id) REFERENCES notifications(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "notifications_targets_notifications_id_foreign" ON "public"."notifications_targets" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."notifications_targets" ADD CONSTRAINT "notifications_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "notifications_targets_targets_id_foreign" ON "public"."notifications_targets" IS NULL;
+
+--- END ALTER TABLE "public"."notifications_targets" ---
+
+--- BEGIN ALTER TABLE "public"."prompts_translations" ---
+
+ALTER TABLE IF EXISTS "public"."prompts_translations" DROP CONSTRAINT IF EXISTS "prompts_translations_prompts_id_foreign";
+
+DROP INDEX IF EXISTS prompts_translations_prompts_id_languages_code_uindex;
+
+ALTER TABLE IF EXISTS "public"."prompts_translations"
+	ALTER COLUMN "prompts_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_translations" ADD CONSTRAINT "prompts_translations_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "prompts_translations_prompts_id_foreign" ON "public"."prompts_translations" IS NULL;
+
+CREATE UNIQUE INDEX prompts_translations_prompts_id_languages_code_uindex ON public.prompts_translations USING btree (prompts_id, languages_code);
+
+COMMENT ON INDEX "public"."prompts_translations_prompts_id_languages_code_uindex"  IS NULL;
+
+--- END ALTER TABLE "public"."prompts_translations" ---
+
+--- BEGIN ALTER TABLE "public"."prompts_targets" ---
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_prompts_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+	ALTER COLUMN "prompts_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" DROP CONSTRAINT IF EXISTS "prompts_targets_targets_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."prompts_targets"
+	ALTER COLUMN "targets_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_prompts_id_foreign" FOREIGN KEY (prompts_id) REFERENCES prompts(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "prompts_targets_prompts_id_foreign" ON "public"."prompts_targets" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."prompts_targets" ADD CONSTRAINT "prompts_targets_targets_id_foreign" FOREIGN KEY (targets_id) REFERENCES targets(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "prompts_targets_targets_id_foreign" ON "public"."prompts_targets" IS NULL;
+
+--- END ALTER TABLE "public"."prompts_targets" ---
+
+--- BEGIN ALTER TABLE "public"."achievementconditions_studytopics" ---
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_achievem__2e3395b2_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+	ALTER COLUMN "achievementconditions_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" DROP CONSTRAINT IF EXISTS "achievementconditions_studytopics_studytopics_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics"
+	ALTER COLUMN "studytopics_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" FOREIGN KEY (achievementconditions_id) REFERENCES achievementconditions(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievementconditions_studytopics_achievem__2e3395b2_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."achievementconditions_studytopics" ADD CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" FOREIGN KEY (studytopics_id) REFERENCES studytopics(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "achievementconditions_studytopics_studytopics_id_foreign" ON "public"."achievementconditions_studytopics" IS NULL;
+
+--- END ALTER TABLE "public"."achievementconditions_studytopics" ---
+
+--- BEGIN ALTER TABLE "public"."faqs_usergroups" ---
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_faqs_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+	ALTER COLUMN "faqs_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" DROP CONSTRAINT IF EXISTS "faqs_usergroups_usergroups_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups"
+	ALTER COLUMN "usergroups_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_faqs_id_foreign" FOREIGN KEY (faqs_id) REFERENCES faqs(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "faqs_usergroups_faqs_id_foreign" ON "public"."faqs_usergroups" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."faqs_usergroups" ADD CONSTRAINT "faqs_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "faqs_usergroups_usergroups_code_foreign" ON "public"."faqs_usergroups" IS NULL;
+
+--- END ALTER TABLE "public"."faqs_usergroups" ---
+
+--- BEGIN ALTER TABLE "public"."assetstreams_audio_languages" ---
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_assetstreams_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+	ALTER COLUMN "assetstreams_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" DROP CONSTRAINT IF EXISTS "assetstreams_audio_languages_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages"
+	ALTER COLUMN "languages_code" DROP NOT NULL,
+	ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "assetstreams_audio_languages_assetstreams_id_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_audio_languages" ADD CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+
+COMMENT ON CONSTRAINT "assetstreams_audio_languages_languages_code_foreign" ON "public"."assetstreams_audio_languages" IS NULL;
+
+--- END ALTER TABLE "public"."assetstreams_audio_languages" ---
+
+--- BEGIN CREATE TABLE "public"."collections_items" ---
+
+CREATE TABLE IF NOT EXISTS "public"."collections_items" (
+	"collection_id" int4 NULL  ,
+	"date_created" timestamptz NULL  ,
+	"date_updated" timestamptz NULL  ,
+	"episode_id" int4 NULL  ,
+	"id" int4 NOT NULL DEFAULT nextval('collections_items_id_seq'::regclass) ,
+	"page_id" int4 NULL  ,
+	"season_id" int4 NULL  ,
+	"show_id" int4 NULL  ,
+	"sort" int4 NULL  ,
+	"type" varchar(255) NULL DEFAULT NULL::character varying ,
+	"user_created" uuid NULL  ,
+	"user_updated" uuid NULL  ,
+	"link_id" int4 NULL  ,
+	CONSTRAINT "collections_items_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE ,
+	CONSTRAINT "collections_items_episode_id_foreign" FOREIGN KEY (episode_id) REFERENCES episodes(id) ON DELETE SET NULL ,
+	CONSTRAINT "collections_items_link_id_foreign" FOREIGN KEY (link_id) REFERENCES links(id) ON DELETE SET NULL ,
+	CONSTRAINT "collections_items_page_id_foreign" FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE SET NULL ,
+	CONSTRAINT "collections_items_pkey" PRIMARY KEY (id) ,
+	CONSTRAINT "collections_items_season_id_foreign" FOREIGN KEY (season_id) REFERENCES seasons(id) ON DELETE SET NULL ,
+	CONSTRAINT "collections_items_show_id_foreign" FOREIGN KEY (show_id) REFERENCES shows(id) ON DELETE SET NULL ,
+	CONSTRAINT "collections_items_user_created_foreign" FOREIGN KEY (user_created) REFERENCES directus_users(id) ,
+	CONSTRAINT "collections_items_user_updated_foreign" FOREIGN KEY (user_updated) REFERENCES directus_users(id)
+);
+
+GRANT SELECT ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT INSERT ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT UPDATE ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT DELETE ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRUNCATE ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT REFERENCES ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT TRIGGER ON TABLE "public"."collections_items" TO directus; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+GRANT SELECT ON TABLE "public"."collections_items" TO api; --WARN: Grant\Revoke privileges to a role can occure in a sql error during execution if role is missing to the target database!
+
+COMMENT ON COLUMN "public"."collections_items"."collection_id"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."date_created"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."date_updated"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."episode_id"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."id"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."page_id"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."season_id"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."show_id"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."sort"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."type"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."user_created"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."user_updated"  IS NULL;
+
+
+COMMENT ON COLUMN "public"."collections_items"."link_id"  IS NULL;
+
+COMMENT ON CONSTRAINT "collections_items_collection_id_foreign" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_episode_id_foreign" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_link_id_foreign" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_page_id_foreign" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_pkey" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_season_id_foreign" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_show_id_foreign" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_user_created_foreign" ON "public"."collections_items" IS NULL;
+
+
+COMMENT ON CONSTRAINT "collections_items_user_updated_foreign" ON "public"."collections_items" IS NULL;
+
+COMMENT ON TABLE "public"."collections_items"  IS NULL;
+
+--- END CREATE TABLE "public"."collections_items" ---
+
+--- BEGIN ALTER TABLE "public"."assetstreams_subtitle_languages" ---
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_assetstreams_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+	ALTER COLUMN "assetstreams_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" DROP CONSTRAINT IF EXISTS "assetstreams_subtitle_languages_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages"
+	ALTER COLUMN "languages_code" DROP NOT NULL,
+	ALTER COLUMN "languages_code" SET DEFAULT NULL::character varying;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" FOREIGN KEY (assetstreams_id) REFERENCES assetstreams(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_assetstreams_id_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."assetstreams_subtitle_languages" ADD CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code);
+
+COMMENT ON CONSTRAINT "assetstreams_subtitle_languages_languages_code_foreign" ON "public"."assetstreams_subtitle_languages" IS NULL;
+
+--- END ALTER TABLE "public"."assetstreams_subtitle_languages" ---
+
+--- BEGIN ALTER TABLE "public"."applicationgroups_usergroups" ---
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_applicationgroups_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+	ALTER COLUMN "applicationgroups_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" DROP CONSTRAINT IF EXISTS "applicationgroups_usergroups_usergroups_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups"
+	ALTER COLUMN "usergroups_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" FOREIGN KEY (applicationgroups_id) REFERENCES applicationgroups(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "applicationgroups_usergroups_applicationgroups_id_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."applicationgroups_usergroups" ADD CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" FOREIGN KEY (usergroups_code) REFERENCES usergroups(code) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "applicationgroups_usergroups_usergroups_code_foreign" ON "public"."applicationgroups_usergroups" IS NULL;
+
+--- END ALTER TABLE "public"."applicationgroups_usergroups" ---
+
+--- BEGIN ALTER TABLE "public"."games_styledimages" ---
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_games_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+	ALTER COLUMN "games_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" DROP CONSTRAINT IF EXISTS "games_styledimages_styledimages_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."games_styledimages"
+	ALTER COLUMN "styledimages_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_games_id_foreign" FOREIGN KEY (games_id) REFERENCES games(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "games_styledimages_games_id_foreign" ON "public"."games_styledimages" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."games_styledimages" ADD CONSTRAINT "games_styledimages_styledimages_id_foreign" FOREIGN KEY (styledimages_id) REFERENCES styledimages(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "games_styledimages_styledimages_id_foreign" ON "public"."games_styledimages" IS NULL;
+
+--- END ALTER TABLE "public"."games_styledimages" ---
+
+--- BEGIN ALTER TABLE "public"."timedmetadata_translations" ---
+
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations" DROP CONSTRAINT IF EXISTS "timedmetadata_translations_timedmetadata_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations"
+	ALTER COLUMN "timedmetadata_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."timedmetadata_translations" ADD CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" FOREIGN KEY (timedmetadata_id) REFERENCES timedmetadata(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "timedmetadata_translations_timedmetadata_id_foreign" ON "public"."timedmetadata_translations" IS NULL;
+
+--- END ALTER TABLE "public"."timedmetadata_translations" ---
+
+--- BEGIN ALTER TABLE "public"."calendarentries_translations" ---
+
+ALTER TABLE IF EXISTS "public"."calendarentries_translations" DROP CONSTRAINT IF EXISTS "calendarentries_translations_calendarentries_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."calendarentries_translations"
+	ALTER COLUMN "calendarentries_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."calendarentries_translations" ADD CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" FOREIGN KEY (calendarentries_id) REFERENCES calendarentries(id) ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT "calendarentries_translations_calendarentries_id_foreign" ON "public"."calendarentries_translations" IS NULL;
+
+--- END ALTER TABLE "public"."calendarentries_translations" ---
+
+--- BEGIN ALTER TABLE "public"."messagetemplates_translations" ---
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_messagetemplates_id_foreign";
+
+DROP INDEX IF EXISTS messagetemplates_translations_messagetemplates_id_languages_cod;
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations"
+	ALTER COLUMN "messagetemplates_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" DROP CONSTRAINT IF EXISTS "messagetemplates_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "messagetemplates_translations_languages_code_foreign" ON "public"."messagetemplates_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."messagetemplates_translations" ADD CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" FOREIGN KEY (messagetemplates_id) REFERENCES messagetemplates(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "messagetemplates_translations_messagetemplates_id_foreign" ON "public"."messagetemplates_translations" IS NULL;
+
+CREATE UNIQUE INDEX messagetemplates_translations_messagetemplates_id_languages_cod ON public.messagetemplates_translations USING btree (messagetemplates_id, languages_code);
+
+COMMENT ON INDEX "public"."messagetemplates_translations_messagetemplates_id_languages_cod"  IS NULL;
+
+--- END ALTER TABLE "public"."messagetemplates_translations" ---
+
+--- BEGIN ALTER TABLE "public"."songcollections_translations" ---
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_songcollections_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+	ALTER COLUMN "songcollections_id" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" DROP CONSTRAINT IF EXISTS "songcollections_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations"
+	ALTER COLUMN "languages_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "songcollections_translations_languages_code_foreign" ON "public"."songcollections_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."songcollections_translations" ADD CONSTRAINT "songcollections_translations_songcollections_id_foreign" FOREIGN KEY (songcollections_id) REFERENCES songcollections(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "songcollections_translations_songcollections_id_foreign" ON "public"."songcollections_translations" IS NULL;
+
+--- END ALTER TABLE "public"."songcollections_translations" ---
+
+--- BEGIN ALTER TABLE "public"."phrases_translations" ---
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_phrases_key_foreign";
+
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+	ALTER COLUMN "phrases_key" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" DROP CONSTRAINT IF EXISTS "phrases_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."phrases_translations"
+	ALTER COLUMN "languages_code" DROP NOT NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "phrases_translations_languages_code_foreign" ON "public"."phrases_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."phrases_translations" ADD CONSTRAINT "phrases_translations_phrases_key_foreign" FOREIGN KEY (phrases_key) REFERENCES phrases(key) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "phrases_translations_phrases_key_foreign" ON "public"."phrases_translations" IS NULL;
+
+--- END ALTER TABLE "public"."phrases_translations" ---
+
+--- BEGIN ALTER TABLE "public"."playlists" ---
+
+ALTER TABLE IF EXISTS "public"."playlists" DROP CONSTRAINT IF EXISTS "playlists_collection_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."playlists" ADD CONSTRAINT "playlists_collection_id_foreign" FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "playlists_collection_id_foreign" ON "public"."playlists" IS NULL;
+
+--- END ALTER TABLE "public"."playlists" ---
+
+--- BEGIN ALTER TABLE "public"."playlists_translations" ---
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_languages_code_foreign";
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_languages_code_foreign" FOREIGN KEY (languages_code) REFERENCES languages(code) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "playlists_translations_languages_code_foreign" ON "public"."playlists_translations" IS NULL;
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" DROP CONSTRAINT IF EXISTS "playlists_translations_playlists_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."playlists_translations" ADD CONSTRAINT "playlists_translations_playlists_id_foreign" FOREIGN KEY (playlists_id) REFERENCES playlists(id) ON DELETE SET NULL;
+
+COMMENT ON CONSTRAINT "playlists_translations_playlists_id_foreign" ON "public"."playlists_translations" IS NULL;
+
+--- END ALTER TABLE "public"."playlists_translations" ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+INSERT INTO "public"."directus_collections" ("collection", "icon", "note", "display_template", "hidden", "singleton", "translations", "archive_field", "archive_app_filter", "archive_value", "unarchive_value", "sort_field", "accountability", "color", "item_duplication_fields", "sort", "group", "collapse", "preview_url", "versioning")  VALUES ('collections_items', NULL, NULL, '{{page_id.translations}}{{show_id.translations}}{{season_id.translations}}{{episode_id.translations}}', true, false, NULL, NULL, true, NULL, NULL, 'sort', 'all', NULL, NULL, 2, 'collections', 'open', NULL, false);
+
+--- END SYNCHRONIZE TABLE "public"."directus_collections" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display", "display_options", "readonly", "hidden", "sort", "width", "translations", "note", "conditions", "required", "group", "validation", "validation_message")  VALUES (684, 'collections', 'collections_items', 'o2m', 'list-o2m', '{"limit":100,"fields":["type","page_id.translations","show_id.translations","season_id.translations","episode_id.translations","link_id.translations"],"enableSearchFilter":true,"template":null,"enableLink":true,"enableSelect":false}', 'related-values', NULL, false, true, 3, 'full', NULL, NULL, '[{"name":"Hidden if not Select","rule":{"_and":[{"filter_type":{"_neq":"select"}}]},"hidden":true,"options":{"layout":"list","enableCreate":true,"enableSelect":true,"limit":15,"enableSearchFilter":false,"enableLink":false}}]', false, 'config', NULL, NULL);
+
+--- END SYNCHRONIZE TABLE "public"."directus_fields" RECORDS ---
+
+--- BEGIN SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---
+
+UPDATE "public"."directus_relations" SET "one_field" = 'collections_items' WHERE "id" = 211;
+
+--- END SYNCHRONIZE TABLE "public"."directus_relations" RECORDS ---


### PR DESCRIPTION
Not very easy to see what's going on here, but try to look through the names of what I'm changing and see if you agree or not.

These are the tables (+ related tables) removed in these migrations:
- collection_items
  - deprecated a while back by collection_entries
- categories
- lists

Other than that, the constraints and database types have been fixed to increase the data quality.

I'm expecting this to fail migration when pushing to prod, but I will remove conflicts /fix it manually when needed, unless you have a better suggestion.