### PR TITLE
Feat/imagorvideo service

### DIFF
--- a/backend.code-workspace
+++ b/backend.code-workspace
@@ -11,6 +11,9 @@
     },
     {
       "path": "cms"
+    },
+    {
+      "path": "infra"
     }
   ],
   "settings": {

--- a/infra/background-jobs.tf
+++ b/infra/background-jobs.tf
@@ -93,6 +93,16 @@ resource "google_cloud_run_service" "background_worker" {
           value = google_sql_user.background_worker.name
         }
 
+        env {
+          name  = "IMAGOR_VIDEO_BASE_URL"
+          value = "${module.imagorvideo.url}/"
+        }
+
+        env {
+          name  = "IMAGOR_SECRET"
+          value = module.imagorvideo.secret
+        }
+
         dynamic "env" {
           for_each = module.background_worker_secrets.data
           iterator = v

--- a/infra/imagorvideo/main.tf
+++ b/infra/imagorvideo/main.tf
@@ -110,8 +110,18 @@ resource "google_cloud_run_service" "imagorvideo" {
 }
 
 resource "google_cloud_run_service_iam_policy" "noauth_imagorvideo" {
-  project     = google_project.brunstadtv.project_id
+  project     = var.project_id
   service     = google_cloud_run_service.imagorvideo.name
   location    = google_cloud_run_service.imagorvideo.location
   policy_data = data.google_iam_policy.noauth.policy_data
+}
+
+
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
 }

--- a/infra/imagorvideo/main.tf
+++ b/infra/imagorvideo/main.tf
@@ -1,0 +1,117 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.35.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.35.0"
+    }
+  }
+}
+
+output "secret" {
+  value = random_password.imagorvideo.result
+}
+
+variable "project_id" {
+  description = "The project id"
+}
+
+variable "env" {
+  description = "The environment to deploy to"
+}
+
+variable "gcp_region" {
+  description = "The region to deploy to"
+}
+
+resource "google_service_account" "imagorvideo" {
+  project      = var.project_id
+  account_id   = "imagorvideo"
+  display_name = "Service Account for imagorvideo cloudrun instance"
+}
+
+resource "random_password" "imagorvideo" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "google_cloud_run_service" "imagorvideo" {
+  project  = var.project_id
+  provider = google-beta
+  name     = "imagorvideo-${var.env}"
+  location = var.gcp_region
+
+  autogenerate_revision_name = true
+
+  metadata {
+    annotations = {
+      "run.googleapis.com/ingress" = "all"
+    }
+  }
+
+  template {
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = "3"
+        "run.googleapis.com/sandbox"       = "gvisor"
+      }
+    }
+
+    spec {
+      container_concurrency = 100
+      timeout_seconds       = 60
+      service_account_name  = google_service_account.imagorvideo.email
+
+      containers {
+        image = "shumc/imagorvideo:0.4.11"
+
+        ports {
+          name           = "http1"
+          container_port = 8000
+        }
+
+        env {
+          name  = "IMAGOR_SECRET"
+          value = random_password.imagorvideo.result
+        }
+
+        resources {
+          limits = {
+            cpu    = "2000m"
+            memory = "2Gi"
+          }
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  depends_on = []
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].labels,
+      template[0].metadata[0].labels,
+      metadata[0].annotations,
+      template[0].metadata[0].annotations,
+      template[0].spec[0].containers[0].image, // The image is managed by the deploy, we just need an initial one
+      traffic[0].latest_revision,
+      traffic[0].revision_name,
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth_imagorvideo" {
+  project     = google_project.brunstadtv.project_id
+  service     = google_cloud_run_service.imagorvideo.name
+  location    = google_cloud_run_service.imagorvideo.location
+  policy_data = data.google_iam_policy.noauth.policy_data
+}

--- a/infra/imagorvideo/main.tf
+++ b/infra/imagorvideo/main.tf
@@ -11,9 +11,14 @@ terraform {
   }
 }
 
+output "url" {
+  value = google_cloud_run_service.imagorvideo.status[0].url
+}
+
 output "secret" {
   value = random_password.imagorvideo.result
 }
+
 
 variable "project_id" {
   description = "The project id"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -77,3 +77,14 @@ module "imgx_cdn" {
     aws.us_east_1 = aws.us_east_1
   }
 }
+
+module "imagorvideo" {
+  source     = "./imagorvideo"
+  env        = var.env
+  project_id = google_project.brunstadtv.project_id
+  gcp_region = var.gcp-region
+  providers = {
+    google      = google
+    google-beta = google-beta
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -18,6 +18,10 @@ provider "google" {
   region = var.gcp-region
 }
 
+provider "google-beta" {
+  region = var.gcp-region
+}
+
 module "vod_cdn" {
   source               = "./vod-cdn"
   env                  = var.env


### PR DESCRIPTION
Here's the diff

```hcl
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.bcc-media-platform.google_cloud_run_service.background_worker will be updated in-place
  ~ resource "google_cloud_run_service" "background_worker" {
        id                         = "locations/europe-west4/namespaces/btv-platform-prod-2/services/background-worker-prod"
        name                       = "background-worker-prod"
        # (4 unchanged attributes hidden)

      ~ template {
          ~ spec {
                # (3 unchanged attributes hidden)

              ~ containers {
                    # (3 unchanged attributes hidden)

                  - env {
                      - name = "ALGOLIA_API_KEY" -> null

                      - value_from {
                          - secret_key_ref {
                              - key  = "1" -> null
                              - name = "algolia-key" -> null
                            }
                        }
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  - env {
                      - name = "AUTH0_CLIENT_SECRET" -> null

                      - value_from {
                          - secret_key_ref {
                              - key  = "1" -> null
                              - name = "worker_auth0_client_secret" -> null
                            }
                        }
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  - env {
                      - name = "AWS_ACCESS_KEY_ID" -> null

                      - value_from {
                          - secret_key_ref {
                              - key  = "1" -> null
                              - name = "AWS_ACCESS_KEY_ID" -> null
                            }
                        }
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  - env {
                      - name = "AWS_SECRET_ACCESS_KEY" -> null

                      - value_from {
                          - secret_key_ref {
                              - key  = "1" -> null
                              - name = "AWS_SECRET_ACCESS_KEY" -> null
                            }
                        }
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  - env {
                      - name = "CROWDIN_TOKEN" -> null

                      - value_from {
                          - secret_key_ref {
                              - key  = "2" -> null
                              - name = "crowdin-token" -> null
                            }
                        }
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  - env {
                      - name = "DIRECTUS_KEY" -> null

                      - value_from {
                          - secret_key_ref {
                              - key  = "2" -> null
                              - name = "directus-key" -> null
                            }
                        }
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  - env {
                      - name = "PGPASSWORD" -> null

                      - value_from {
                          - secret_key_ref {
                              - key  = "1" -> null
                              - name = "postgres_background_worker_password" -> null
                            }
                        }
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  # Warning: this block will be marked as sensitive and will not
                  # display in UI output after applying this change.
                  ~ env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }
                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }

                    # (3 unchanged blocks hidden)
                }
            }

            # (1 unchanged block hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.bcc-media-platform.module.imagorvideo.google_cloud_run_service.imagorvideo will be created
  + resource "google_cloud_run_service" "imagorvideo" {
      + autogenerate_revision_name = true
      + id                         = (known after apply)
      + location                   = "europe-west4"
      + name                       = "imagorvideo-prod"
      + project                    = "btv-platform-prod-2"
      + status                     = (known after apply)

      + metadata {
          + annotations      = {
              + "run.googleapis.com/ingress" = "all"
            }
          + generation       = (known after apply)
          + labels           = (known after apply)
          + namespace        = (known after apply)
          + resource_version = (known after apply)
          + self_link        = (known after apply)
          + uid              = (known after apply)
        }

      + template {
          + metadata {
              + annotations      = {
                  + "autoscaling.knative.dev/maxScale" = "3"
                  + "run.googleapis.com/sandbox"       = "gvisor"
                }
              + generation       = (known after apply)
              + name             = (known after apply)
              + namespace        = (known after apply)
              + resource_version = (known after apply)
              + self_link        = (known after apply)
              + uid              = (known after apply)
            }
          + spec {
              + container_concurrency = 100
              + service_account_name  = (known after apply)
              + serving_state         = (known after apply)
              + timeout_seconds       = 60

              + containers {
                  + image = "shumc/imagorvideo:0.4.11"

                  + env {
                      # At least one attribute in this block is (or was) sensitive,
                      # so its contents will not be displayed.
                    }

                  + ports {
                      + container_port = 8000
                      + name           = "http1"
                    }

                  + resources {
                      + limits = {
                          + "cpu"    = "2000m"
                          + "memory" = "2Gi"
                        }
                    }
                }
            }
        }

      + traffic {
          + latest_revision = true
          + percent         = 100
          + url             = (known after apply)
        }
    }

  # module.bcc-media-platform.module.imagorvideo.google_cloud_run_service_iam_policy.noauth_imagorvideo will be created
  + resource "google_cloud_run_service_iam_policy" "noauth_imagorvideo" {
      + etag        = (known after apply)
      + id          = (known after apply)
      + location    = "europe-west4"
      + policy_data = jsonencode(
            {
              + bindings = [
                  + {
                      + members = [
                          + "allUsers",
                        ]
                      + role    = "roles/run.invoker"
                    },
                ]
            }
        )
      + project     = "btv-platform-prod-2"
      + service     = "imagorvideo-prod"
    }

  # module.bcc-media-platform.module.imagorvideo.google_service_account.imagorvideo will be created
  + resource "google_service_account" "imagorvideo" {
      + account_id   = "imagorvideo"
      + disabled     = false
      + display_name = "Service Account for imagorvideo cloudrun instance"
      + email        = (known after apply)
      + id           = (known after apply)
      + member       = (known after apply)
      + name         = (known after apply)
      + project      = "btv-platform-prod-2"
      + unique_id    = (known after apply)
    }

  # module.bcc-media-platform.module.imagorvideo.random_password.imagorvideo will be created
  + resource "random_password" "imagorvideo" {
      + bcrypt_hash      = (sensitive value)
      + id               = (known after apply)
      + length           = 16
      + lower            = true
      + min_lower        = 0
      + min_numeric      = 0
      + min_special      = 0
      + min_upper        = 0
      + number           = true
      + numeric          = true
      + override_special = "!#$%&*()-_=+[]{}<>:?"
      + result           = (sensitive value)
      + special          = true
      + upper            = true
    }

Plan: 4 to add, 1 to change, 0 to destroy.
```