### PR TITLE
fix: timedmetadata durations

### DIFF
--- a/backend/asset/timedmetadata.go
+++ b/backend/asset/timedmetadata.go
@@ -152,7 +152,6 @@ func ingestOneTimedMetadata(ctx context.Context, queries *sqlc.Queries, inputTm 
 	}
 
 	for _, assetID := range assetIDs {
-		realTm.ID = uuid.New()
 		realTm.AssetID = null.IntFrom(int64(assetID))
 		tmID, err := queries.InsertTimedMetadata(ctx, realTm)
 		if err != nil {

--- a/backend/graph/admin/schema.resolvers.go
+++ b/backend/graph/admin/schema.resolvers.go
@@ -42,11 +42,9 @@ func (r *episodesResolver) ImportTimedMetadata(ctx context.Context, obj *model.E
 		return false, err
 	}
 	for _, m := range metadata {
-		m.ID = uuid.New()
 		m.EpisodeID = null_v4.IntFrom(intID)
 
 		_, err = r.Queries.InsertTimedMetadata(ctx, sqlc.InsertTimedMetadataParams{
-			ID:          m.ID,
 			EpisodeID:   m.EpisodeID,
 			Title:       m.Title.String,
 			Description: m.Description.String,
@@ -87,11 +85,9 @@ func (r *mediaItemsResolver) ImportTimedMetadata(ctx context.Context, obj *model
 		return false, err
 	}
 	for _, m := range metadata {
-		m.ID = uuid.New()
 		m.MediaitemID = uuid.NullUUID{UUID: mediaItem.ID, Valid: true}
 
 		_, err = r.Queries.InsertTimedMetadata(ctx, sqlc.InsertTimedMetadataParams{
-			ID:          m.ID,
 			MediaitemID: m.MediaitemID,
 			Title:       m.Title.String,
 			Description: m.Description.String,

--- a/backend/sqlc/mediaitems.sql.go
+++ b/backend/sqlc/mediaitems.sql.go
@@ -7,8 +7,10 @@ package sqlc
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/google/uuid"
+	null_v4 "gopkg.in/guregu/null.v4"
 )
 
 const getMediaItemByID = `-- name: GetMediaItemByID :one
@@ -45,4 +47,101 @@ func (q *Queries) GetMediaItemByID(ctx context.Context, id uuid.UUID) (Mediaitem
 		&i.PrimaryEpisodeID,
 	)
 	return i, err
+}
+
+const insertMediaItem = `-- name: InsertMediaItem :one
+INSERT INTO mediaitems (
+    id,
+    label,
+    title,
+    description,
+    type,
+    asset_id,
+    parent_episode_id,
+    parent_starts_at,
+    parent_ends_at,
+    published_at,
+    production_date,
+    parent_id,
+    content_type,
+    audience,
+    agerating_code,
+    translations_required,
+    timedmetadata_from_asset,
+    available_from,
+    available_to,
+    primary_episode_id
+)
+VALUES (
+    gen_random_uuid(),
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10,
+    $11,
+    $12,
+    $13,
+    $14,
+    $15,
+    $16,
+    $17,
+    $18,
+    $19
+)
+RETURNING id
+`
+
+type InsertMediaItemParams struct {
+	Label                  string          `db:"label" json:"label"`
+	Title                  null_v4.String  `db:"title" json:"title"`
+	Description            null_v4.String  `db:"description" json:"description"`
+	Type                   string          `db:"type" json:"type"`
+	AssetID                null_v4.Int     `db:"asset_id" json:"assetId"`
+	ParentEpisodeID        null_v4.Int     `db:"parent_episode_id" json:"parentEpisodeId"`
+	ParentStartsAt         sql.NullFloat64 `db:"parent_starts_at" json:"parentStartsAt"`
+	ParentEndsAt           sql.NullFloat64 `db:"parent_ends_at" json:"parentEndsAt"`
+	PublishedAt            null_v4.Time    `db:"published_at" json:"publishedAt"`
+	ProductionDate         null_v4.Time    `db:"production_date" json:"productionDate"`
+	ParentID               uuid.NullUUID   `db:"parent_id" json:"parentId"`
+	ContentType            null_v4.String  `db:"content_type" json:"contentType"`
+	Audience               null_v4.String  `db:"audience" json:"audience"`
+	AgeratingCode          null_v4.String  `db:"agerating_code" json:"ageratingCode"`
+	TranslationsRequired   bool            `db:"translations_required" json:"translationsRequired"`
+	TimedmetadataFromAsset bool            `db:"timedmetadata_from_asset" json:"timedmetadataFromAsset"`
+	AvailableFrom          null_v4.Time    `db:"available_from" json:"availableFrom"`
+	AvailableTo            null_v4.Time    `db:"available_to" json:"availableTo"`
+	PrimaryEpisodeID       null_v4.Int     `db:"primary_episode_id" json:"primaryEpisodeId"`
+}
+
+func (q *Queries) InsertMediaItem(ctx context.Context, arg InsertMediaItemParams) (uuid.UUID, error) {
+	row := q.db.QueryRowContext(ctx, insertMediaItem,
+		arg.Label,
+		arg.Title,
+		arg.Description,
+		arg.Type,
+		arg.AssetID,
+		arg.ParentEpisodeID,
+		arg.ParentStartsAt,
+		arg.ParentEndsAt,
+		arg.PublishedAt,
+		arg.ProductionDate,
+		arg.ParentID,
+		arg.ContentType,
+		arg.Audience,
+		arg.AgeratingCode,
+		arg.TranslationsRequired,
+		arg.TimedmetadataFromAsset,
+		arg.AvailableFrom,
+		arg.AvailableTo,
+		arg.PrimaryEpisodeID,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
 }

--- a/queries/mediaitems.sql
+++ b/queries/mediaitems.sql
@@ -1,2 +1,49 @@
 -- name: GetMediaItemByID :one
 SELECT * FROM mediaitems WHERE id = @id::uuid;
+
+-- name: InsertMediaItem :one
+INSERT INTO mediaitems (
+    id,
+    label,
+    title,
+    description,
+    type,
+    asset_id,
+    parent_episode_id,
+    parent_starts_at,
+    parent_ends_at,
+    published_at,
+    production_date,
+    parent_id,
+    content_type,
+    audience,
+    agerating_code,
+    translations_required,
+    timedmetadata_from_asset,
+    available_from,
+    available_to,
+    primary_episode_id
+)
+VALUES (
+    gen_random_uuid(),
+    @label,
+    @title,
+    @description,
+    @type,
+    @asset_id,
+    @parent_episode_id,
+    @parent_starts_at,
+    @parent_ends_at,
+    @published_at,
+    @production_date,
+    @parent_id,
+    @content_type,
+    @audience,
+    @agerating_code,
+    @translations_required,
+    @timedmetadata_from_asset,
+    @available_from,
+    @available_to,
+    @primary_episode_id
+)
+RETURNING id;

--- a/queries/timedmetadata.sql
+++ b/queries/timedmetadata.sql
@@ -7,28 +7,41 @@ LEFT JOIN mediaitems m on (m.id = tm.mediaitem_id) OR (m.timedmetadata_from_asse
 WHERE tm.id = ANY ($1::uuid[]);
 
 -- name: getTimedMetadata :many
-SELECT md.id,
-       md.type,
-       md.content_type,
-       md.song_id,
-       (SELECT array_agg(c.person_id) FROM "contributions" c WHERE c.timedmetadata_id = md.id)::uuid[] AS person_ids,
-       md.title                                                  AS original_title,
-       md.description                                            AS original_description,
+SELECT tm.id,
+       tm.type,
+       tm.content_type,
+       tm.song_id,
+       (SELECT array_agg(c.person_id) FROM "contributions" c WHERE c.timedmetadata_id = tm.id)::uuid[] AS person_ids,
+       tm.title                                                  AS original_title,
+       tm.description                                            AS original_description,
        COALESCE((SELECT json_object_agg(ts.languages_code, ts.title)
                  FROM timedmetadata_translations ts
-                 WHERE ts.timedmetadata_id = md.id), '{}')::json AS title,
+                 WHERE ts.timedmetadata_id = tm.id), '{}')::json AS title,
        COALESCE((SELECT json_object_agg(ts.languages_code, ts.description)
                  FROM timedmetadata_translations ts
-                 WHERE ts.timedmetadata_id = md.id), '{}')::json AS description,
-       md.seconds,
-       md.highlight,
-       md.mediaitem_id,
+                 WHERE ts.timedmetadata_id = tm.id), '{}')::json AS description,
+       tm.seconds,
+       tm.highlight,
+       tm.mediaitem_id,
        COALESCE(images.images, '{}'::json)            AS images,
-       COALESCE((SELECT nextMd.seconds - md.seconds FROM timedmetadata nextMd
-                 WHERE nextMd.mediaitem_id = md.mediaitem_id or nextMd.asset_id = md.asset_id
-                   AND nextMd.seconds > md.seconds
-                 ORDER BY nextMd.seconds LIMIT 1), 0)::float as duration
-FROM timedmetadata md
+       COALESCE((
+          -- if there is a next timedmetadata, calculate the duration between the current and the next timedmetadata
+          SELECT nextTm.seconds - tm.seconds
+          FROM timedmetadata nextTm
+          WHERE (nextTm.mediaitem_id = tm.mediaitem_id OR nextTm.asset_id = tm.asset_id)
+          AND nextTm.seconds > tm.seconds
+          ORDER BY nextTm.seconds
+          LIMIT 1
+        ), (
+          -- if there is no next timedmetadata, calculate the duration of the asset
+          SELECT asset.duration - tm.seconds
+          FROM assets asset
+          WHERE asset.id = tm.asset_id
+          OR asset.id = mi.asset_id
+          LIMIT 1
+        ), 0)::float as duration
+FROM timedmetadata tm
+LEFT JOIN mediaitems mi ON (mi.id = tm.mediaitem_id)
 LEFT JOIN (
     SELECT
     simg.timedmetadata_id,
@@ -38,8 +51,8 @@ LEFT JOIN (
     JOIN directus_files df ON (img.file = df.id)
     WHERE simg.timedmetadata_id = ANY(@ids::uuid[])
     GROUP BY simg.timedmetadata_id
-) images ON (images.timedmetadata_id = md.id)
-WHERE md.id = ANY (@ids::uuid[]);
+) images ON (images.timedmetadata_id = tm.id)
+WHERE tm.id = ANY (@ids::uuid[]);
 
 -- name: InsertTimedMetadata :one
 INSERT INTO timedmetadata (
@@ -60,7 +73,7 @@ INSERT INTO timedmetadata (
   song_id
 )
 VALUES (
-  @id,
+  gen_random_uuid(),
   @status,
   NOW(),
   NOW(),


### PR DESCRIPTION
duration was wrong for the last chapter in an asset since no "next tm"

see timedmetadata.sql
the comments in the query should explain whats going on