### PR TITLE
feat(shorts): Support for importing shorts from BQ

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -5,6 +5,7 @@
     <file url="file://$PROJECT_DIR$/migrations/00011_applications.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/migrations/special/post/01-admin-user.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/queries/contributions.sql" dialect="PostgreSQL" />
+    <file url="file://$PROJECT_DIR$/queries/shorts.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/queries/timedmetadata.sql" dialect="PostgreSQL" />
     <file url="PROJECT" dialect="PostgreSQL" />
   </component>

--- a/backend/cmd/jobs/env.go
+++ b/backend/cmd/jobs/env.go
@@ -126,7 +126,7 @@ func getEnvConfig() envConfig {
 			Domain: os.Getenv("MEMBERS_API_DOMAIN"),
 		},
 		BigQuery: statistics.BigQueryConfig{
-			ProjectID: os.Getenv("BIGQUERY_PROJECT"), // Export disabed if empty
+			ProjectID: os.Getenv("BIGQUERY_PROJECT"), // Export disabled if empty
 			DatasetID: os.Getenv("BIGQUERY_DATASET"),
 		},
 		VideoManipulator: videomanipulatorConfig{

--- a/backend/cmd/jobs/server/server.go
+++ b/backend/cmd/jobs/server/server.go
@@ -145,6 +145,8 @@ func (s Server) ProcessMessage(c *gin.Context) {
 		err = s.services.GetSearchService().Reindex(ctx)
 	case events.TypeExportAnswersToBQ:
 		err = s.services.GetStatisticHandler().HandleAnswerExportToBQ(ctx)
+	case events.TypeImportShortsScores:
+		err = s.services.GetStatisticHandler().HandleImportShortsScores(ctx)
 	case events.TypeTranslationsSync:
 		err = s.runIfNotLocked(ctx, fmt.Sprintf("event:%s:%s", e.Type(), e.ID()), func() error {
 			return crowdin.HandleEvent(ctx, s.services, e)

--- a/backend/cmd/pubsub-helper/main.go
+++ b/backend/cmd/pubsub-helper/main.go
@@ -254,6 +254,8 @@ func main() {
 		simpleEvent(projectId, topicId, events.TypeExportAnswersToBQ)
 	case "searchReindex":
 		simpleEvent(projectId, topicId, events.TypeSearchReindex)
+	case "shortsScores":
+		simpleEvent(projectId, topicId, events.TypeImportShortsScores)
 	case "ingest":
 		send(projectId, topicId)
 	case "show.update":

--- a/backend/events/constants.go
+++ b/backend/events/constants.go
@@ -15,4 +15,5 @@ const (
 	TypeSearchReindex               = "search.reindex"
 	TypeTranslationsSync            = "translations.sync"
 	TypeExportAnswersToBQ           = "statistics.exportanswers"
+	TypeImportShortsScores          = "statistics.importshortsscores"
 )

--- a/backend/sqlc/episode-queries.go
+++ b/backend/sqlc/episode-queries.go
@@ -141,9 +141,7 @@ func (q *Queries) ListEpisodes(ctx context.Context) ([]common.Episode, error) {
 	if err != nil {
 		return nil, err
 	}
-	return q.mapListToEpisodes(lo.Map(items, func(i listEpisodesRow, _ int) listEpisodesRow {
-		return listEpisodesRow(i)
-	})), nil
+	return q.mapListToEpisodes(items), nil
 }
 
 // GetKey returns the id for this row

--- a/backend/sqlc/models.go
+++ b/backend/sqlc/models.go
@@ -1382,13 +1382,14 @@ type SectionsUsergroup struct {
 }
 
 type Short struct {
-	ID          uuid.UUID     `db:"id" json:"id"`
-	Status      string        `db:"status" json:"status"`
-	UserCreated uuid.NullUUID `db:"user_created" json:"userCreated"`
-	DateCreated null_v4.Time  `db:"date_created" json:"dateCreated"`
-	UserUpdated uuid.NullUUID `db:"user_updated" json:"userUpdated"`
-	DateUpdated null_v4.Time  `db:"date_updated" json:"dateUpdated"`
-	MediaitemID uuid.NullUUID `db:"mediaitem_id" json:"mediaitemId"`
+	ID          uuid.UUID       `db:"id" json:"id"`
+	Status      string          `db:"status" json:"status"`
+	UserCreated uuid.NullUUID   `db:"user_created" json:"userCreated"`
+	DateCreated null_v4.Time    `db:"date_created" json:"dateCreated"`
+	UserUpdated uuid.NullUUID   `db:"user_updated" json:"userUpdated"`
+	DateUpdated null_v4.Time    `db:"date_updated" json:"dateUpdated"`
+	MediaitemID uuid.NullUUID   `db:"mediaitem_id" json:"mediaitemId"`
+	Score       sql.NullFloat64 `db:"score" json:"score"`
 }
 
 type ShortsUsergroup struct {

--- a/backend/sqlc/shorts.sql.go
+++ b/backend/sqlc/shorts.sql.go
@@ -59,6 +59,22 @@ func (q *Queries) ListSegmentedShortIDsForRoles(ctx context.Context, roles []str
 	return items, nil
 }
 
+const updateShortsScore = `-- name: UpdateShortsScore :exec
+UPDATE shorts
+SET score = $1::float8
+WHERE id = $2::uuid
+`
+
+type UpdateShortsScoreParams struct {
+	Score float64   `db:"score" json:"score"`
+	ID    uuid.UUID `db:"id" json:"id"`
+}
+
+func (q *Queries) UpdateShortsScore(ctx context.Context, arg UpdateShortsScoreParams) error {
+	_, err := q.db.ExecContext(ctx, updateShortsScore, arg.Score, arg.ID)
+	return err
+}
+
 const getMediaIDForShorts = `-- name: getMediaIDForShorts :many
 SELECT sh.id, sh.mediaitem_id
 FROM "public"."shorts" sh

--- a/migrations/00301_add_shorts_score.sql
+++ b/migrations/00301_add_shorts_score.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+/**********************************************************/
+/*** SCRIPT AUTHOR: Matjaz Debelak (matjaz@debelak.org) ***/
+/***    CREATED ON: 2024-09-19T13:17:03.407Z            ***/
+/**********************************************************/
+
+ALTER TABLE IF EXISTS "public"."shorts" ADD COLUMN IF NOT EXISTS "score" float4 NULL DEFAULT '0'::real ;
+
+COMMENT ON COLUMN "public"."shorts"."score"  IS NULL;
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display", "display_options", "readonly", "hidden", "sort", "width", "translations", "note", "conditions", "required", "group", "validation", "validation_message")  VALUES (1486, 'shorts', 'score', NULL, NULL, '{"placeholder":"0.0","iconLeft":"scoreboard"}', NULL, NULL, true, true, 9, 'full', NULL, NULL, NULL, true, NULL, NULL, NULL);
+
+-- +goose Down
+
+ALTER TABLE IF EXISTS "public"."shorts" DROP COLUMN IF EXISTS "score" CASCADE;
+
+DELETE FROM "public"."directus_fields" WHERE "id" = 1486;

--- a/queries/shorts.sql
+++ b/queries/shorts.sql
@@ -55,3 +55,8 @@ SELECT s.id,
 FROM shorts s
          JOIN mediaitems_view mi ON mi.id = s.mediaitem_id
 WHERE s.mediaitem_id = @id::uuid;
+
+-- name: UpdateShortsScore :exec
+UPDATE shorts
+SET score = @score::float8
+WHERE id = @id::uuid;


### PR DESCRIPTION
This adds the field in the DB and the needed machinery to import the scores.
I will later add automatic trigger via terraform.

The data is not used anywhere yet.