### PR TITLE
Optimize view query

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -3,6 +3,7 @@
   <component name="SqlDialectMappings">
     <file url="file://$PROJECT_DIR$/migrations/00001_init.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/migrations/00011_applications.sql" dialect="PostgreSQL" />
+    <file url="file://$PROJECT_DIR$/migrations/00304_optimize_mediaitem_view.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/migrations/special/post/01-admin-user.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/queries/contributions.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/queries/shorts.sql" dialect="PostgreSQL" />

--- a/backend/cmd/api/env.go
+++ b/backend/cmd/api/env.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"github.com/bcc-code/bcc-media-platform/backend/email"
+	"github.com/bcc-code/bcc-media-platform/backend/log"
 	"os"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/bcc-code/bcc-media-platform/backend/search"
 
 	"github.com/bcc-code/bcc-media-platform/backend/auth0"
+	"github.com/joho/godotenv"
 	"github.com/samber/lo"
 )
 
@@ -155,6 +157,11 @@ func (a awsConfig) GetTempStorageBucket() string {
 }
 
 func getEnvConfig() envConfig {
+	err := godotenv.Load("backend/cmd/api/.env")
+	if err == nil {
+		log.L.Warn().Msg("Loaded .env file")
+	}
+
 	aud := lo.Map(strings.Split(os.Getenv("AUTH0_AUDIENCES"), ","),
 		func(s string, _ int) string {
 			return strings.TrimSpace(s)

--- a/backend/cmd/api/loaders.go
+++ b/backend/cmd/api/loaders.go
@@ -278,6 +278,9 @@ func initBatchLoaders(queries *sqlc.Queries, membersClient *members.Client) *com
 		TimedMetadataLoader: loaders.New(ctx, queries.GetTimedMetadata, loaders.WithName("timedmetadata-loader"), loaders.WithKeyFunc(func(i common.TimedMetadata) uuid.UUID {
 			return i.ID
 		})),
+		ChaptersLoader: loaders.NewListLoader(ctx, queries.GetChaptersForEpisodeID, func(i common.TimedMetadata) int {
+			return int(i.ParentEpisodeID.Int64)
+		}),
 		PhraseLoader: loaders.New(ctx, queries.GetPhrases, loaders.WithName("phrases-loader"), loaders.WithKeyFunc(func(i common.Phrase) string {
 			return i.Key
 		})),

--- a/backend/common/items.go
+++ b/backend/common/items.go
@@ -142,9 +142,8 @@ type Episode struct {
 	Assets       LocaleMap[int] `json:"assets"`
 	AssetVersion string         `json:"assetVersion"`
 
-	Images           Images      `json:"images"`
-	TagIDs           []int       `json:"tagIds"`
-	TimedMetadataIDs []uuid.UUID `json:"timedMetadataIds"`
+	Images Images `json:"images"`
+	TagIDs []int  `json:"tagIds"`
 
 	PublicTitle      null.String  `json:"publicTitle"`
 	Title            LocaleString `json:"title"`
@@ -229,17 +228,18 @@ var (
 
 // TimedMetadata item type
 type TimedMetadata struct {
-	ID          uuid.UUID
-	Type        string
-	Timestamp   float64
-	Duration    float64
-	Title       LocaleString `json:"title"`
-	Description LocaleString `json:"description"`
-	ContentType ContentType
-	PersonIDs   []uuid.UUID
-	SongID      uuid.NullUUID
-	MediaItemID uuid.NullUUID
-	Images      Images
+	ID              uuid.UUID
+	Type            string
+	Timestamp       float64
+	Duration        float64
+	Title           LocaleString `json:"title"`
+	Description     LocaleString `json:"description"`
+	ContentType     ContentType
+	PersonIDs       []uuid.UUID
+	SongID          uuid.NullUUID
+	MediaItemID     uuid.NullUUID
+	Images          Images
+	ParentEpisodeID null.Int
 }
 
 // Short item type

--- a/backend/common/loaders.go
+++ b/backend/common/loaders.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-
 	"github.com/bcc-code/bcc-media-platform/backend/loaders"
 	"github.com/bcc-code/bcc-media-platform/backend/members"
 	"github.com/google/uuid"
@@ -94,6 +93,7 @@ type BatchLoaders struct {
 
 	MediaItemPrimaryEpisodeIDLoader *loaders.Loader[uuid.UUID, *int]
 	TimedMetadataLoader             *loaders.Loader[uuid.UUID, *TimedMetadata]
+	ChaptersLoader                  *loaders.Loader[int, []*TimedMetadata]
 	PersonLoader                    *loaders.Loader[uuid.UUID, *Person]
 	SongLoader                      *loaders.Loader[uuid.UUID, *Song]
 	PhraseLoader                    *loaders.Loader[string, *Phrase]

--- a/backend/graph/api/chapter.utils.go
+++ b/backend/graph/api/chapter.utils.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/bcc-code/bcc-media-platform/backend/common"
@@ -11,6 +12,84 @@ import (
 	"github.com/bcc-code/bcc-media-platform/backend/utils"
 	"github.com/google/uuid"
 )
+
+func resolveChapters(ctx context.Context, loaders *common.BatchLoaders, episodeID string) ([]*model.Chapter, error) {
+	episodeIDInt, err := strconv.Atoi(episodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	tms, err := loaders.ChaptersLoader.Get(ctx, episodeIDInt)
+	if err != nil {
+		return nil, err
+	}
+
+	chapters := make([]*model.Chapter, 0, len(tms))
+
+	for _, tm := range tms {
+
+		ginCtx, _ := utils.GinCtx(ctx)
+		languages := user.GetLanguagesFromCtx(ginCtx)
+		title := tm.Title.Get(languages)
+		phrase, _ := loaders.PhraseLoader.Get(ctx, tm.ContentType.Value)
+		emptyTitle := title == ""
+		if emptyTitle && phrase != nil {
+			title = phrase.Value.Get(languages)
+		}
+
+		switch tm.ContentType {
+		case common.ContentTypeSong, common.ContentTypeSingAlong:
+			if !tm.SongID.Valid {
+				break
+			}
+			song, _ := loaders.SongLoader.Get(ctx, tm.SongID.UUID)
+			if song == nil {
+				break
+			}
+			if emptyTitle {
+				if phrase != nil {
+					title = fmt.Sprintf("%s - %s", phrase.Value.Get(languages), song.Title.Get(languages))
+				} else {
+					title = song.Title.Get(languages)
+				}
+			} else {
+				title = strings.Replace(title, "{{song.title}}", song.Title.Get(languages), -1)
+			}
+		case common.ContentTypeSpeech, common.ContentTypeInterview, common.ContentTypeTestimony:
+			if len(tm.PersonIDs) != 1 {
+				break
+			}
+			personID := tm.PersonIDs[0]
+			person, _ := loaders.PersonLoader.Get(ctx, personID)
+			if person == nil {
+				break
+			}
+			if emptyTitle {
+				if phrase != nil {
+					title = fmt.Sprintf("%s - %s", phrase.Value.Get(languages), person.Name)
+				} else {
+					title = person.Name
+				}
+			} else {
+				title = strings.Replace(title, "{{person.name}}", person.Name, -1)
+			}
+		}
+		chapters = append(chapters, &model.Chapter{
+			ID:          tm.ID.String(),
+			Title:       title,
+			Description: tm.Description.GetValueOrNil(languages),
+			Start:       int(tm.Timestamp),
+			Duration:    int(tm.Duration),
+			Image:       imageOrFallback(ctx, tm.Images, nil),
+			ContentType: &model.ContentType{Code: tm.ContentType.Value},
+			Episode: &model.Episode{
+				ID: episodeID,
+			},
+		})
+	}
+
+	return chapters, nil
+}
 
 func resolveChapter(ctx context.Context, loaders *common.BatchLoaders, episodeID string, id uuid.UUID) (*model.Chapter, error) {
 	tm, err := loaders.TimedMetadataLoader.Get(ctx, id)

--- a/backend/graph/api/episode-resolver.utils.go
+++ b/backend/graph/api/episode-resolver.utils.go
@@ -322,29 +322,5 @@ func (r *episodeResolver) getTitleWithCollection(ctx context.Context, episode *m
 }
 
 func (r *episodeResolver) getChapters(ctx context.Context, episodeId string) ([]*model.Chapter, error) {
-	i, err := r.Loaders.EpisodeLoader.Get(ctx, utils.AsInt(episodeId))
-	if err != nil || !i.AssetID.Valid {
-		return nil, err
-	}
-	metadataItems, err := r.Loaders.TimedMetadataLoader.GetMany(ctx, i.TimedMetadataIDs)
-	if err != nil {
-		return nil, err
-	}
-	metadataItems = lo.Filter(metadataItems, func(i *common.TimedMetadata, _ int) bool {
-		return i.Type == "chapter"
-	})
-
-	r.Loaders.PhraseLoader.LoadMany(ctx, lo.Uniq(lo.Map(metadataItems, func(i *common.TimedMetadata, _ int) string {
-		return i.ContentType.Value
-	})))
-
-	var out []*model.Chapter
-	for _, tm := range metadataItems {
-		chapter, err := resolveChapter(ctx, r.Loaders, episodeId, tm.ID)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, chapter)
-	}
-	return out, nil
+	return resolveChapters(ctx, r.Loaders, episodeId)
 }

--- a/backend/sqlc/episode-queries.go
+++ b/backend/sqlc/episode-queries.go
@@ -64,7 +64,6 @@ func (q *Queries) mapToEpisodes(episodes []getEpisodesRow) []common.Episode {
 			TagIDs: lo.Map(e.TagIds, func(id int32, _ int) int {
 				return int(id)
 			}),
-			TimedMetadataIDs: e.TimedmetadataIds,
 		}
 	})
 }
@@ -121,7 +120,6 @@ func (q *Queries) mapListToEpisodes(episodes []listEpisodesRow) []common.Episode
 			TagIDs: lo.Map(e.TagIds, func(id int32, _ int) int {
 				return int(id)
 			}),
-			TimedMetadataIDs: e.TimedmetadataIds,
 		}
 	})
 }

--- a/backend/sqlc/episodes.sql.go
+++ b/backend/sqlc/episodes.sql.go
@@ -401,10 +401,9 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type,
-       mi.timedmetadata_ids
+       mi.content_type
 FROM episodes e
-         LEFT JOIN mediaitems_by_episodes($1::int[]) mi ON mi.id = e.mediaitem_id
+         LEFT JOIN mediaitems_by_episodes_v2($1::int[]) mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id
          LEFT JOIN seasons s ON e.season_id = s.id
          LEFT JOIN shows sh ON s.show_id = sh.id
@@ -447,7 +446,6 @@ type getEpisodesRow struct {
 	Agerating             string                `db:"agerating" json:"agerating"`
 	Audience              null_v4.String        `db:"audience" json:"audience"`
 	ContentType           null_v4.String        `db:"content_type" json:"contentType"`
-	TimedmetadataIds      []uuid.UUID           `db:"timedmetadata_ids" json:"timedmetadataIds"`
 }
 
 func (q *Queries) getEpisodes(ctx context.Context, dollar_1 []int32) ([]getEpisodesRow, error) {
@@ -492,7 +490,6 @@ func (q *Queries) getEpisodes(ctx context.Context, dollar_1 []int32) ([]getEpiso
 			&i.Agerating,
 			&i.Audience,
 			&i.ContentType,
-			pq.Array(&i.TimedmetadataIds),
 		); err != nil {
 			return nil, err
 		}
@@ -604,10 +601,9 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type,
-       mi.timedmetadata_ids
+       mi.content_type
 FROM episodes e
-         LEFT JOIN mediaitems_view mi ON mi.id = e.mediaitem_id
+         LEFT JOIN mediaitems_view_v2 mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id
          LEFT JOIN seasons s ON e.season_id = s.id
          LEFT JOIN shows sh ON s.show_id = sh.id
@@ -648,7 +644,6 @@ type listEpisodesRow struct {
 	Agerating             string                `db:"agerating" json:"agerating"`
 	Audience              null_v4.String        `db:"audience" json:"audience"`
 	ContentType           null_v4.String        `db:"content_type" json:"contentType"`
-	TimedmetadataIds      []uuid.UUID           `db:"timedmetadata_ids" json:"timedmetadataIds"`
 }
 
 func (q *Queries) listEpisodes(ctx context.Context) ([]listEpisodesRow, error) {
@@ -693,7 +688,6 @@ func (q *Queries) listEpisodes(ctx context.Context) ([]listEpisodesRow, error) {
 			&i.Agerating,
 			&i.Audience,
 			&i.ContentType,
-			pq.Array(&i.TimedmetadataIds),
 		); err != nil {
 			return nil, err
 		}

--- a/backend/sqlc/models.go
+++ b/backend/sqlc/models.go
@@ -1099,6 +1099,34 @@ type MediaitemsView struct {
 	TimedmetadataIds     []uuid.UUID     `db:"timedmetadata_ids" json:"timedmetadataIds"`
 }
 
+type MediaitemsViewV2 struct {
+	ID                   uuid.UUID       `db:"id" json:"id"`
+	Assets               json.RawMessage `db:"assets" json:"assets"`
+	AssetID              null_v4.Int     `db:"asset_id" json:"assetId"`
+	OriginalTitle        null_v4.String  `db:"original_title" json:"originalTitle"`
+	OriginalDescription  null_v4.String  `db:"original_description" json:"originalDescription"`
+	Title                json.RawMessage `db:"title" json:"title"`
+	Description          json.RawMessage `db:"description" json:"description"`
+	Images               json.RawMessage `db:"images" json:"images"`
+	ParentID             uuid.NullUUID   `db:"parent_id" json:"parentId"`
+	ParentEpisodeID      null_v4.Int     `db:"parent_episode_id" json:"parentEpisodeId"`
+	ParentStartsAt       sql.NullFloat64 `db:"parent_starts_at" json:"parentStartsAt"`
+	ParentEndsAt         sql.NullFloat64 `db:"parent_ends_at" json:"parentEndsAt"`
+	AvailableFrom        time.Time       `db:"available_from" json:"availableFrom"`
+	AvailableTo          time.Time       `db:"available_to" json:"availableTo"`
+	Label                string          `db:"label" json:"label"`
+	AgeratingCode        null_v4.String  `db:"agerating_code" json:"ageratingCode"`
+	Audience             null_v4.String  `db:"audience" json:"audience"`
+	ContentType          null_v4.String  `db:"content_type" json:"contentType"`
+	ProductionDate       time.Time       `db:"production_date" json:"productionDate"`
+	PublishedAt          time.Time       `db:"published_at" json:"publishedAt"`
+	TranslationsRequired bool            `db:"translations_required" json:"translationsRequired"`
+	DateUpdated          null_v4.Time    `db:"date_updated" json:"dateUpdated"`
+	Duration             null_v4.Int     `db:"duration" json:"duration"`
+	AssetDateUpdated     null_v4.Time    `db:"asset_date_updated" json:"assetDateUpdated"`
+	TagIds               []int32         `db:"tag_ids" json:"tagIds"`
+}
+
 type Message struct {
 	ID          int32          `db:"id" json:"id"`
 	Status      string         `db:"status" json:"status"`

--- a/backend/sqlc/timedmetadata-queries.go
+++ b/backend/sqlc/timedmetadata-queries.go
@@ -21,6 +21,7 @@ func (q *Queries) GetTimedMetadata(ctx context.Context, ids []uuid.UUID) ([]comm
 		if contentType == nil {
 			contentType = &common.ContentTypeSpeech
 		}
+
 		return common.TimedMetadata{
 			ID:          i.ID,
 			Type:        i.Type,
@@ -28,11 +29,44 @@ func (q *Queries) GetTimedMetadata(ctx context.Context, ids []uuid.UUID) ([]comm
 			PersonIDs:   i.PersonIds,
 			SongID:      i.SongID,
 			Timestamp:   float64(i.Seconds),
-			Duration:    float64(i.Duration),
+			Duration:    i.Duration,
 			Title:       title,
 			Description: description,
 			MediaItemID: i.MediaitemID,
 			Images:      q.getImages(i.Images),
+		}
+	}), nil
+}
+
+// GetChaptersForEpisodeID returns chapters for the specified episode id
+func (q *Queries) GetChaptersForEpisodeID(ctx context.Context, ids []int) ([]common.TimedMetadata, error) {
+	idsInt32 := lo.Map(ids, func(i int, _ int) int32 {
+		return int32(i)
+	})
+	rows, err := q.getChaptesFromEpisode(ctx, idsInt32)
+	if err != nil {
+		return nil, err
+	}
+	return lo.Map(rows, func(i getChaptesFromEpisodeRow, _ int) common.TimedMetadata {
+		title := toLocaleString(i.Title, i.OriginalTitle.String)
+		description := toLocaleString(i.Description, i.OriginalDescription.String)
+		contentType := common.ContentTypes.Parse(i.ContentType.String)
+		if contentType == nil {
+			contentType = &common.ContentTypeSpeech
+		}
+		return common.TimedMetadata{
+			ID:              i.ID,
+			Type:            i.Type,
+			ContentType:     *contentType,
+			PersonIDs:       i.PersonIds,
+			SongID:          i.SongID,
+			Timestamp:       float64(i.Seconds),
+			Duration:        i.Duration,
+			Title:           title,
+			Description:     description,
+			MediaItemID:     i.MediaitemID,
+			Images:          q.getImages(i.Images),
+			ParentEpisodeID: i.EpisodeID,
 		}
 	}), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/goodsign/monday v1.0.1
 	github.com/google/uuid v1.6.0
 	github.com/graph-gophers/dataloader/v7 v7.1.0
+	github.com/joho/godotenv v1.5.1
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/lib/pq v1.10.9
 	github.com/microcosm-cc/bluemonday v1.0.26

--- a/go.sum
+++ b/go.sum
@@ -776,6 +776,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/migrations/00304_optimize_mediaitem_view.sql
+++ b/migrations/00304_optimize_mediaitem_view.sql
@@ -1,0 +1,145 @@
+-- +goose Up
+DROP VIEW IF EXISTS mediaitems_view_v2 CASCADE ;
+create or replace view mediaitems_view_v2
+            (id, assets, asset_id, original_title, original_description, title, description, images, parent_id,
+             parent_episode_id, parent_starts_at, parent_ends_at, available_from, available_to, label, agerating_code,
+             audience, content_type, production_date, published_at, translations_required, date_updated, duration,
+             asset_date_updated, tag_ids)
+as
+SELECT mi.id,
+       ma.assets,
+       mi.asset_id,
+       mi.title                                                                         AS original_title,
+       mi.description                                                                   AS original_description,
+       COALESCE(titles.title, '{}'::json)                                               AS title,
+       COALESCE(descriptions.description, '{}'::json)                                   AS description,
+       COALESCE(images.images, '{}'::json)                                              AS images,
+       mi.parent_id,
+       mi.parent_episode_id,
+       mi.parent_starts_at,
+       mi.parent_ends_at,
+       COALESCE(mi.available_from, '1900-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone  AS available_from,
+       COALESCE(mi.available_to, '3000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone    AS available_to,
+       mi.label,
+       mi.agerating_code,
+       mi.audience,
+       mi.content_type,
+       COALESCE(mi.production_date, '2000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone AS production_date,
+       COALESCE(mi.published_at, '2000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone    AS published_at,
+       mi.translations_required,
+       COALESCE(mi.date_created, mi.date_updated)                                       AS date_updated,
+       a.duration,
+       a.date_updated                                                                   AS asset_date_updated,
+       tags.tags::int[]                                                                        AS tag_ids
+FROM mediaitems mi
+         LEFT JOIN (SELECT ts.mediaitems_id,
+                           json_object_agg(ts.languages_code, ts.title) AS title
+                    FROM mediaitems_translations ts
+                    GROUP BY ts.mediaitems_id) titles ON titles.mediaitems_id = mi.id
+         LEFT JOIN (SELECT ts.mediaitems_id,
+                           json_object_agg(ts.languages_code, ts.description) AS description
+                    FROM mediaitems_translations ts
+                    GROUP BY ts.mediaitems_id) descriptions ON descriptions.mediaitems_id = mi.id
+         LEFT JOIN (SELECT simg.mediaitems_id,
+                           json_agg(json_build_object('style', img.style, 'language', img.language, 'filename_disk',
+                                                      df.filename_disk)) AS images
+                    FROM mediaitems_styledimages simg
+                             JOIN styledimages img ON img.id = simg.styledimages_id
+                             JOIN directus_files df ON img.file = df.id
+                    GROUP BY simg.mediaitems_id) images ON images.mediaitems_id = mi.id
+         LEFT JOIN (SELECT ma_1.mediaitems_id,
+                           json_object_agg(ma_1.language, ma_1.assets_id) AS assets
+                    FROM mediaitems_assets ma_1
+                    GROUP BY ma_1.mediaitems_id) ma ON ma.mediaitems_id = mi.id
+         LEFT JOIN assets a ON a.id = mi.asset_id
+         LEFT JOIN (SELECT t.mediaitems_id,
+                           array_agg(t.tags_id) AS tags
+                    FROM mediaitems_tags t
+                    GROUP BY t.mediaitems_id) tags ON tags.mediaitems_id = mi.id;
+
+grant select on mediaitems_view_v2 to api;
+
+grant select on mediaitems_view_v2 to background_worker;
+
+grant select on mediaitems_view_v2 to onsite_backup;
+
+grant select on mediaitems_view_v2 to staging_sync;
+
+-- +goose StatementBegin
+create or replace function mediaitems_by_episodes_v2(episodeids integer[]) returns SETOF mediaitems_view_v2
+    language plpgsql
+as
+$$
+BEGIN
+    RETURN QUERY (WITH mids AS (
+        SELECT mediaitem_id FROM episodes WHERE episodes.id = ANY(episodeids)
+    )
+                  SELECT mi.id,
+                         COALESCE(ma.assets, '{}'::json)                                                  AS assets,
+                         mi.asset_id,
+                         mi.title                                                                         AS original_title,
+                         mi.description                                                                   AS original_description,
+                         COALESCE(titles.title, '{}'::json)                                               AS title,
+                         COALESCE(descriptions.description, '{}'::json)                                   AS description,
+                         COALESCE(images.images, '{}'::json)                                              AS images,
+                         mi.parent_id,
+                         mi.parent_episode_id,
+                         mi.parent_starts_at,
+                         mi.parent_ends_at,
+                         COALESCE(mi.available_from, '1900-01-01 00:00:00'::timestamp without time zone)  AS available_from,
+                         COALESCE(mi.available_to, '3000-01-01 00:00:00'::timestamp without time zone)    AS available_to,
+                         mi.label,
+                         mi.agerating_code,
+                         mi.audience,
+                         mi.content_type,
+                         COALESCE(mi.production_date, '2000-01-01 00:00:00'::timestamp without time zone) AS production_date,
+                         COALESCE(mi.published_at, '2000-01-01 00:00:00'::timestamp without time zone)    AS published_at,
+                         mi.translations_required,
+                         COALESCE(mi.date_created, mi.date_updated)                                       AS date_updated,
+                         a.duration,
+                         a.date_updated                                                                   AS asset_date_updated,
+                         tags.tags                                                                        AS tag_ids
+                  FROM mediaitems mi
+                           JOIN episodes e ON e.mediaitem_id = mi.id
+                           LEFT JOIN (SELECT ts.mediaitems_id,
+                                             json_object_agg(ts.languages_code, ts.title) AS title
+                                      FROM mediaitems_translations ts
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ts.mediaitems_id) titles ON titles.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT ts.mediaitems_id,
+                                             json_object_agg(ts.languages_code, ts.description) AS description
+                                      FROM mediaitems_translations ts
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ts.mediaitems_id) descriptions ON descriptions.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT simg.mediaitems_id,
+                                             json_agg(json_build_object('style', img.style, 'language', img.language, 'filename_disk',
+                                                                        df.filename_disk)) AS images
+                                      FROM mediaitems_styledimages simg
+                                               JOIN styledimages img ON img.id = simg.styledimages_id
+                                               JOIN directus_files df ON img.file = df.id
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY simg.mediaitems_id) images ON images.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT ma_1.mediaitems_id,
+                                             json_object_agg(ma_1.language, ma_1.assets_id) AS assets
+                                      FROM mediaitems_assets ma_1
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ma_1.mediaitems_id) ma ON ma.mediaitems_id = mi.id
+                           LEFT JOIN assets a ON a.id = mi.asset_id
+                           LEFT JOIN (SELECT t.mediaitems_id,
+                                             array_agg(t.tags_id) AS tags
+                                      FROM mediaitems_tags t
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY t.mediaitems_id) tags ON tags.mediaitems_id = mi.id
+                  WHERE e.id = ANY(episodeids));
+    END;
+$$;
+-- +goose StatementEnd
+
+
+grant execute on function mediaitems_by_episodes(integer[]) to api;
+
+
+-- +goose Down
+
+DROP FUNCTION IF EXISTS mediaitems_by_episodes_v2;
+DROP VIEW IF EXISTS mediaitems_view_v2;

--- a/queries/episodes.sql
+++ b/queries/episodes.sql
@@ -34,10 +34,9 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type,
-       mi.timedmetadata_ids
+       mi.content_type
 FROM episodes e
-         LEFT JOIN mediaitems_view mi ON mi.id = e.mediaitem_id
+         LEFT JOIN mediaitems_view_v2 mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id
          LEFT JOIN seasons s ON e.season_id = s.id
          LEFT JOIN shows sh ON s.show_id = sh.id
@@ -81,10 +80,9 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type,
-       mi.timedmetadata_ids
+       mi.content_type
 FROM episodes e
-         LEFT JOIN mediaitems_by_episodes($1::int[]) mi ON mi.id = e.mediaitem_id
+         LEFT JOIN mediaitems_by_episodes_v2($1::int[]) mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id
          LEFT JOIN seasons s ON e.season_id = s.id
          LEFT JOIN shows sh ON s.show_id = sh.id

--- a/queries/timedmetadata.sql
+++ b/queries/timedmetadata.sql
@@ -114,3 +114,55 @@ DELETE FROM timedmetadata WHERE mediaitem_id = @mediaitem_id::uuid;
 
 -- name: ClearAssetTimedMetadata :exec
 DELETE FROM timedmetadata WHERE asset_id = @asset_id;
+
+-- name: getChaptesFromEpisode :many
+SELECT
+    tm.id,
+    tm.type,
+    tm.episode_id,
+    tm.content_type,
+    tm.song_id,
+    (SELECT array_agg(c.person_id) FROM "contributions" c WHERE c.timedmetadata_id = tm.id)::uuid[] AS person_ids,
+    tm.title                                                  AS original_title,
+    tm.description                                            AS original_description,
+    COALESCE((SELECT json_object_agg(ts.languages_code, ts.title)
+              FROM timedmetadata_translations ts
+              WHERE ts.timedmetadata_id = tm.id), '{}')::json AS title,
+    COALESCE((SELECT json_object_agg(ts.languages_code, ts.description)
+              FROM timedmetadata_translations ts
+              WHERE ts.timedmetadata_id = tm.id), '{}')::json AS description,
+    tm.seconds,
+    tm.highlight,
+    tm.mediaitem_id,
+    COALESCE(images.images, '{}'::json)            AS images,
+    COALESCE((
+                 -- if there is a next timedmetadata, calculate the duration between the current and the next timedmetadata
+                 SELECT nextTm.seconds - tm.seconds
+                 FROM timedmetadata nextTm
+                 WHERE (nextTm.mediaitem_id = tm.mediaitem_id OR nextTm.asset_id = tm.asset_id)
+                   AND nextTm.seconds > tm.seconds
+                 ORDER BY nextTm.seconds
+                 LIMIT 1
+             ), (
+                 -- if there is no next timedmetadata, calculate the duration of the asset
+                 SELECT asset.duration - tm.seconds
+                 FROM assets asset
+                 WHERE asset.id = tm.asset_id
+                    OR asset.id = mi.asset_id
+                 LIMIT 1
+             ), 0)::float as duration
+FROM timedmetadata tm
+         LEFT JOIN public.episodes e on e.id = tm.episode_id
+         LEFT JOIN mediaitems mi ON (mi.id = tm.mediaitem_id)
+         LEFT JOIN (
+    SELECT
+        simg.timedmetadata_id,
+        json_agg(json_build_object('style', img.style, 'language', img.language, 'filename_disk', df.filename_disk)) AS images
+    FROM timedmetadata_styledimages simg
+             JOIN styledimages img ON (img.id = simg.styledimages_id)
+             JOIN directus_files df ON (img.file = df.id)
+    GROUP BY simg.timedmetadata_id
+) images ON (images.timedmetadata_id = tm.id)
+WHERE e.id= ANY(@episode_ids::int[])
+  AND tm.status = 'published'
+  AND tm.type = 'chapter';

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,0 +1,2 @@
+run:
+	pnpm dev


### PR DESCRIPTION
The central point here is that the `mediaitem_view` no longer fetches `timedmetadata`.
The issue was that the query doing that was implemented as a return field and was thus run late in the process and the return had to wait for one "query" per row to complete.

This triggered a rewrite of the `resolveShort` function that was now in one place replaced with `GetShortsForEpisode`, that does away with some more `n+1` style queries.

Currently the `mediaitem_view` and the corresponding stored procedure is replaced by their respective `_v2` versions because I do not want to break the existing deployment. They can be `DROP`ped in the next round of migrations.