### PR TITLE
Add the ability to query shorts scodres on GQL

### DIFF
--- a/backend/common/items.go
+++ b/backend/common/items.go
@@ -250,6 +250,7 @@ type Short struct {
 	Title       LocaleString
 	Description LocaleString
 	Images      Images
+	Score       float64
 	EpisodeID   null.Int
 	StartsAt    null.Float
 	EndsAt      null.Float

--- a/backend/graph/api/model/models_gen.go
+++ b/backend/graph/api/model/models_gen.go
@@ -1189,6 +1189,7 @@ type Short struct {
 	Title         string         `json:"title"`
 	OriginalTitle string         `json:"originalTitle"`
 	Description   *string        `json:"description,omitempty"`
+	Score         float64        `json:"score"`
 	Image         *string        `json:"image,omitempty"`
 	Streams       []*Stream      `json:"streams"`
 	Files         []*File        `json:"files"`

--- a/backend/graph/api/schema/shorts.graphqls
+++ b/backend/graph/api/schema/shorts.graphqls
@@ -3,6 +3,7 @@ type Short implements CollectionItem & PlaylistItem & MediaItem {
     title: String!
     originalTitle: String! @goField(forceResolver: true)
     description: String
+    score: Float! @goField(forceResolver: true) @deprecated(reason: "Only for debugging. Will always be 0 without special flags.")
     image(style: ImageStyle): String @goField(forceResolver: true)
     streams: [Stream!]! @goField(forceResolver: true)
     files: [File!]! @goField(forceResolver: true)

--- a/backend/graph/api/shorts.resolvers.go
+++ b/backend/graph/api/shorts.resolvers.go
@@ -6,6 +6,7 @@ package graph
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"strconv"
 	"strings"
 
@@ -21,6 +22,21 @@ func (r *shortResolver) OriginalTitle(ctx context.Context, obj *model.Short) (st
 		return "", err
 	}
 	return e.Title.Get(*utils.FallbackLanguages()), nil
+}
+
+// Score is the resolver for the score field.
+func (r *shortResolver) Score(ctx context.Context, obj *model.Short) (float64, error) {
+	ginCtx, err := utils.GinCtx(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	featureFlags := utils.GetFeatureFlags(ginCtx)
+	if !featureFlags.Has("debug") {
+		return 0, nil
+	}
+
+	return r.Queries.GetShortScores(ctx, uuid.MustParse(obj.ID))
 }
 
 // Image is the resolver for the image field.

--- a/backend/graph/api/shorts.utils.go
+++ b/backend/graph/api/shorts.utils.go
@@ -269,6 +269,7 @@ func shortToShort(ctx context.Context, short *common.Short) *model.Short {
 		ID:          short.ID.String(),
 		Title:       short.Title.Get(languages),
 		Description: short.Description.GetValueOrNil(languages),
+		Score:       short.Score,
 	}
 }
 

--- a/queries/shorts.sql
+++ b/queries/shorts.sql
@@ -81,3 +81,8 @@ WHERE s.mediaitem_id = @id::uuid;
 UPDATE shorts
 SET score = @score::float8
 WHERE id = @id::uuid;
+
+-- name: GetShortScores :one
+SELECT (((10 - LEAST(10, EXTRACT(DAY FROM current_date - COALESCE(mi.published_at, mi.date_created)))) * 0.5) + score)::float8 as final_score
+FROM shorts s JOIN mediaitems mi ON s.mediaitem_id = mi.id
+WHERE s.id = @id::uuid;


### PR DESCRIPTION
This is related to investigation for https://github.com/bcc-code/bcc-media-platform/issues/1051 but I think it is valuable enough to commit it.

It adds a field `score` to the QGL schema for shorts. This field is currently queried separately so it is "protected" using the `debug` feature flag.

Ideally this would be generally available but I estimate about a day of refactoring to make it a reality.