### PR TITLE
feat: add bmm streak tracking to web

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
         "@urql/vue": "1.3.2",
         "@vueuse/core": "^10.11.1",
         "@vueuse/motion": "^2.2.3",
-        "bccm-video-player": "1.5.6",
+        "bccm-video-player": "1.5.7",
         "graphql": "^16.9.0",
         "graphql-tag": "^2.12.6",
         "rudder-sdk-js": "^2.48.15",
@@ -45,7 +45,8 @@
         "vue": "^3.5.13",
         "vue-i18n": "^10.0.5",
         "vue-router": "^4.4.3",
-        "vue3-lottie": "^3.3.0"
+        "vue3-lottie": "^3.3.0",
+        "@bcc-code/bmm-sdk-fetch": "8.8.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.9.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@auth0/auth0-vue':
         specifier: ^2.3.3
         version: 2.3.3(typescript@5.7.2)(vue-router@4.5.0(vue@3.5.13(typescript@5.7.2)))
+      '@bcc-code/bmm-sdk-fetch':
+        specifier: 8.8.0
+        version: 8.8.0
       '@headlessui/vue':
         specifier: ^1.7.22
         version: 1.7.23(vue@3.5.13(typescript@5.7.2))
@@ -48,8 +51,8 @@ importers:
         specifier: ^2.2.3
         version: 2.2.6(rollup@4.28.1)(vue@3.5.13(typescript@5.7.2))
       bccm-video-player:
-        specifier: 1.5.6
-        version: 1.5.6
+        specifier: 1.5.7
+        version: 1.5.7
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -457,6 +460,9 @@ packages:
   '@babel/types@7.26.3':
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcc-code/bmm-sdk-fetch@8.8.0':
+    resolution: {integrity: sha512-JsYHWO4WmBD+qWgZKC8rnoeyzG/tLnxp1vbM7Xf9DSZhKYWtufB00ZewHQVElT7SqL3QjjzPB9aAIkbE3szXBw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1571,8 +1577,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  bccm-video-player@1.5.6:
-    resolution: {integrity: sha512-tkQmkuTGzkDtXnrcwE5F0q6/nSa6leM0XuYlt3TaKwcfpKWe8JgSbABZ69dfa28GQAqIJNPTRIGWKmiifK9iTw==}
+  bccm-video-player@1.5.7:
+    resolution: {integrity: sha512-2wXggO6kxsF0URMexT2q/5Ig44LvhAfWErONQEF9i59LbbaHrR9zfoSG95I7GT4wkqt1gHQCQTrLQoeKiNuA1w==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -3903,6 +3909,8 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@bcc-code/bmm-sdk-fetch@8.8.0': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -5373,7 +5381,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bccm-video-player@1.5.6:
+  bccm-video-player@1.5.7:
     dependencies:
       '@silvermine/videojs-chromecast': 1.5.0(video.js@8.21.0)
       graphql: 16.9.0

--- a/web/src/components/EpisodeViewer.vue
+++ b/web/src/components/EpisodeViewer.vue
@@ -256,6 +256,9 @@ const checkProgress = async (force?: boolean) => {
     }
 }
 
+// This is a very naive v1.0 of the BMM streak tracking.
+// With this implementation, we have basically no way of preventing the
+// user from skipping forward to the end, and therefore getting the streak point.
 let hasSentHalfwayWatchedEvent = false
 function onVideoProgress(
     currentTime: number,

--- a/web/src/components/EpisodeViewer.vue
+++ b/web/src/components/EpisodeViewer.vue
@@ -256,19 +256,16 @@ const checkProgress = async (force?: boolean) => {
     }
 }
 
-let playedOverHalfCounter = 0
+let hasSentHalfwayWatchedEvent = false
 function onVideoProgress(
     currentTime: number,
     duration: number,
     player: Player
 ) {
     const videoProgressPercent = currentTime / duration
-    if (videoProgressPercent >= 0.5 && playedOverHalfCounter < 20) {
-        playedOverHalfCounter++
-    }
     if (
-        (videoProgressPercent >= 0.5 && playedOverHalfCounter === 10) ||
-        (videoProgressPercent === 1 && playedOverHalfCounter > 10)
+        (videoProgressPercent >= 0.5 && !hasSentHalfwayWatchedEvent) ||
+        videoProgressPercent === 1
     ) {
         const event: ProcessWatchedCommandEvent = {
             episodeId: props.episode.id,
@@ -281,6 +278,7 @@ function onVideoProgress(
         }
 
         new BMM().postStatisticsWatched(event)
+        hasSentHalfwayWatchedEvent = true
     }
 }
 

--- a/web/src/services/bmm.ts
+++ b/web/src/services/bmm.ts
@@ -1,0 +1,73 @@
+import {
+	DefaultConfig,
+	Configuration,
+	StatisticsApi,
+	ProcessWatchedCommandEvent,
+} from '@bcc-code/bmm-sdk-fetch'
+import Auth from './auth'
+import i18n from '@/i18n'
+
+DefaultConfig.config = new Configuration({
+	basePath: 'https://bmm-api.brunstad.org',
+	middleware: [
+		{
+			pre: async (ctx) => {
+				const token = Auth.isAuthenticated().value
+					? await Auth.getToken()
+					: null
+
+				const headers = new Headers(ctx.init.headers)
+				if (token) {
+					headers.set('Authorization', `Bearer ${token}`)
+				}
+
+				if (!headers.has('Accept-Language')) {
+					const language =
+						typeof i18n.global.locale === 'string'
+							? i18n.global.locale
+							: i18n.global.locale.value
+
+					headers.set('Accept-Language', language)
+				}
+
+				ctx.init.headers = headers
+
+				return ctx
+			},
+			post: async (ctx) => {
+				if (
+					!ctx.response ||
+					ctx.response.status < 200 ||
+					ctx.response.status > 300
+				) {
+					const responseContent = await ctx.response.text()
+					try {
+						const errorObject = JSON.parse(responseContent)
+						console.error(errorObject)
+					} catch {
+						console.error(responseContent)
+					}
+				}
+			},
+			onError: async (ctx) => {
+				const responseContent = await ctx.response?.text()
+				if (!responseContent) return
+
+				try {
+					const errorObject = JSON.parse(responseContent)
+					console.error(errorObject)
+				} catch {
+					console.error(responseContent)
+				}
+			},
+		},
+	],
+})
+
+export class BMM {
+	async postStatisticsWatched(event: ProcessWatchedCommandEvent) {
+		return new StatisticsApi().statisticsWatchedPost({
+			processWatchedCommandEvent: [event],
+		})
+	}
+}

--- a/web/src/services/bmm.ts
+++ b/web/src/services/bmm.ts
@@ -6,6 +6,7 @@ import {
 } from '@bcc-code/bmm-sdk-fetch'
 import Auth from './auth'
 import i18n from '@/i18n'
+import { analytics } from './analytics'
 
 DefaultConfig.config = new Configuration({
 	basePath: 'https://bmm-api.brunstad.org',
@@ -43,6 +44,11 @@ DefaultConfig.config = new Configuration({
 					const responseContent = await ctx.response.text()
 					try {
 						const errorObject = JSON.parse(responseContent)
+						analytics.track('error', {
+							code: ctx.response.status,
+							message: '[BMM] could not complete request',
+							data: errorObject
+						})
 						console.error(errorObject)
 					} catch {
 						console.error(responseContent)
@@ -51,10 +57,13 @@ DefaultConfig.config = new Configuration({
 			},
 			onError: async (ctx) => {
 				const responseContent = await ctx.response?.text()
-				if (!responseContent) return
-
 				try {
-					const errorObject = JSON.parse(responseContent)
+					const errorObject = JSON.parse(responseContent ?? '')
+					analytics.track('error', {
+						code: ctx.response?.status,
+						message: '[BMM] an error occured',
+						data: errorObject
+					})
 					console.error(errorObject)
 				} catch {
 					console.error(responseContent)

--- a/web/src/utils/userAgent.ts
+++ b/web/src/utils/userAgent.ts
@@ -4,12 +4,12 @@ export function getOperatingSystem() {
 	const windowsPlatforms = /(win32|win64|windows|wince)/i
 	const iosPlatforms = /(iphone|ipad|ipod)/i
 	if (iosPlatforms.test(userAgent)) {
-		return 'iOS'
+		return 'ios'
 	} else if (windowsPlatforms.test(userAgent)) {
-		return 'Windows'
+		return 'windows'
 	} else if (macosPlatforms.test(userAgent)) {
-		return 'MacOS'
+		return 'macos'
 	} else if (/android/i.test(userAgent)) {
-		return 'Android'
+		return 'android'
 	}
 }

--- a/web/src/utils/userAgent.ts
+++ b/web/src/utils/userAgent.ts
@@ -1,0 +1,15 @@
+export function getOperatingSystem() {
+	const userAgent = window.navigator.userAgent.toLowerCase()
+	const macosPlatforms = /(macintosh|macintel|macppc|mac68k|macppc64|mac68k64)/i
+	const windowsPlatforms = /(win32|win64|windows|wince)/i
+	const iosPlatforms = /(iphone|ipad|ipod)/i
+	if (iosPlatforms.test(userAgent)) {
+		return 'iOS'
+	} else if (windowsPlatforms.test(userAgent)) {
+		return 'Windows'
+	} else if (macosPlatforms.test(userAgent)) {
+		return 'MacOS'
+	} else if (/android/i.test(userAgent)) {
+		return 'Android'
+	}
+}


### PR DESCRIPTION
Adds a call to BMM's `/Statistics/watched` endpoint when watching a video.

There are two scenarios where we call the endpoint:
- The video current time is at > 50% of the video duration, and has been for 10 progress "ticks"  
- The video is finished