### PR TITLE
feat(bq): add status field to bq episodes table

### DIFF
--- a/backend/statistics/item-bq-types.go
+++ b/backend/statistics/item-bq-types.go
@@ -100,6 +100,7 @@ func SeasonFromCommon(s common.Season, tags []common.Tag) Season {
 type Episode struct {
 	ID                    int                 `json:"id"`
 	UUID                  uuid.UUID           `json:"uuid"`
+	Status                common.Status       `json:"status"`
 	Unlisted              bool                `json:"unlisted"`
 	Type                  string              `json:"type"`
 	PreventPublicIndexing bool                `json:"preventPublicIndexing"`
@@ -141,6 +142,7 @@ func EpisodeFromCommon(e common.Episode, tags []common.Tag) Episode {
 	return Episode{
 		ID:                    e.ID,
 		UUID:                  e.UUID,
+		Status:                e.Status,
 		Unlisted:              e.Unlisted(),
 		Type:                  e.Type,
 		PreventPublicIndexing: e.PreventPublicIndexing,


### PR DESCRIPTION
This is probably all that is needed to add `status` to the episodes table in Metabase
@KillerX 

If so, this resolves #441 