### PR TITLE
added custom error handlers for gin and gql that output formated stac…

### DIFF
--- a/backend/cmd/api/handlers.go
+++ b/backend/cmd/api/handlers.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/bcc-code/bcc-media-platform/backend/loaders"
-	"github.com/pkg/errors"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/99designs/gqlgen/graphql"
@@ -94,13 +94,13 @@ func graphqlHandler(
 	h.Use(tracer)
 
 	h.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
-		stackerr := errors.Errorf("panic recovered: %v", err)
+		stackerr := fmt.Errorf("panic recovered: %v", err)
 		log.L.Error().
 			Stack().
 			Err(stackerr).
 			Msg("A panic occurred during GraphQL resolve")
 
-		return errors.New("Internal Server Error")
+		return fmt.Errorf("Internal Server Error")
 	})
 
 	h.SetErrorPresenter(func(ctx context.Context, err error) *gqlerror.Error {
@@ -166,7 +166,6 @@ func adminGraphqlHandler(config envConfig, db *sql.DB, queries *sqlc.Queries, lo
 		log.L.Debug().Msg("No secret for Directus found in environment. Disabling endpoint")
 		return func(c *gin.Context) {
 			c.AbortWithStatus(404)
-			return
 		}
 	}
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -63,12 +63,7 @@ func personalizedLoaderFactory(
 		}
 
 		var roles []string
-		if err != nil {
-			log.L.Error().Err(err).Msg("failed to get gin ctx from context")
-			roles = []string{"unknown"}
-		} else {
-			roles = user.GetRolesFromCtx(ginCtx)
-		}
+		roles = user.GetRolesFromCtx(ginCtx)
 
 		langPreferences := common.GetLanguagePreferencesFromCtx(ginCtx)
 
@@ -143,7 +138,7 @@ func jwksHandler(config *redirectConfig) gin.HandlerFunc {
 	}
 }
 
-func panicHandler(c *gin.Context, err interface{}) {
+func panicHandler(c *gin.Context, err any) {
 	stackerr := errors.Errorf("panic recovered: %v", err)
 	log.L.Error().
 		Stack().

--- a/backend/graph/api/faq.resolvers.go
+++ b/backend/graph/api/faq.resolvers.go
@@ -6,11 +6,11 @@ package graph
 
 import (
 	"context"
-
 	"github.com/bcc-code/bcc-media-platform/backend/common"
 	"github.com/bcc-code/bcc-media-platform/backend/cursors"
 	"github.com/bcc-code/bcc-media-platform/backend/graph/api/generated"
 	"github.com/bcc-code/bcc-media-platform/backend/graph/api/model"
+	"github.com/bcc-code/bcc-media-platform/backend/log"
 	"github.com/bcc-code/bcc-media-platform/backend/utils"
 	"github.com/google/uuid"
 )

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/orsinium-labs/enum v1.3.0
 	github.com/peterldowns/pgtestdb v0.1.1
 	github.com/peterldowns/pgtestdb/migrators/goosemigrator v0.1.1
+	github.com/pkg/errors v0.9.1
 	github.com/pressly/goose/v3 v3.24.3
 	github.com/redis/go-redis/v9 v9.2.1
 	github.com/robbiet480/go.sns v0.0.0-20230523235941-e8d832c79d68
@@ -195,7 +196,6 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
 	github.com/pingcap/log v1.1.0 // indirect
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20250324122243-d51e00e5bbf0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect


### PR DESCRIPTION
This PR adds custom error handlers for both Gin HTTP and GraphQL that:
- Capture panics, format the stacktrace, and using Zerolog
- Return a "Internal Server Error" response

<img width="1201" height="698" alt="image" src="https://github.com/user-attachments/assets/3a1726c4-4534-4187-9c9c-207d90be6d62" />

closes: #1151 
