### PR TITLE
Add topbar search endpoint

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -285,6 +285,7 @@ func main() {
 	r.GET("/", playgroundHandler())
 	r.POST("/admin", adminGraphqlHandler(config, db, queries, ls))
 	r.POST("/public", publicGraphqlHandler(ls))
+	r.GET("/topbarsearch/:term", topbarSearchHandler(searchService))
 	r.GET("/versionz", version.GinHandler)
 
 	if os.Getenv("PPROF") == "TRUE" {

--- a/backend/common/models.go
+++ b/backend/common/models.go
@@ -169,3 +169,11 @@ type ShortIDWithMeta struct {
 	ParentEpisodeID null.Int
 	FinalScore      float64
 }
+
+// TopbarSearchResult for exposing search results in the topbar dropdown
+type TopbarSearchResult struct {
+	Title    string `json:"title"`
+	Subtitle string `json:"subtitle"`
+	Image    string `json:"image"`
+	URL      string `json:"url"`
+}


### PR DESCRIPTION
`/topbarsearch/<SEARCH TERM>`

Forced to elastic search, follows the same permissions as the rest of the system.

Example result:

```
[{"title":"Give and Share","subtitle":"Music Videos • Music videos for children","image":"https://brunstadtv.imgix.net/giogdele.jpg","url":"/episodes/612?utm_source=topbarsearch"},{"title":"Triumphantly happy","subtitle":"Music Videos • Music videos for children","image":"https://brunstadtv.imgix.net/triumferende.jpg","url":"/episodes/613?utm_source=topbarsearch"},{"title":"I can make others happy!","subtitle":"Sunday School for the little ones • Season 1","image":"https://brunstadtv.imgix.net/Jeg_kan_glede_andre.jpg","url":"/episodes/1083?utm_source=topbarsearch"},{"title":"Repay evil with good","subtitle":"Music Videos • Music videos for children","image":"https://brunstadtv.imgix.net/gelde.jpg","url":"/episodes/611?utm_source=topbarsearch"}]
```