### PR TITLE
Add stacktrace rendering to GQL errors

### DIFF
--- a/backend/cmd/api/handlers.go
+++ b/backend/cmd/api/handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bcc-code/bcc-media-platform/backend/utils"
 	"github.com/bcc-code/bmm-sdk-golang"
 	"github.com/gin-gonic/gin"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"strconv"
 )
@@ -95,7 +96,8 @@ func graphqlHandler(
 	h.Use(tracer)
 
 	h.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
-		stackerr := fmt.Errorf("panic recovered: %v", err)
+		// Wrap the panic error with a stack trace using pkg/errors
+		stackerr := pkgerrors.Errorf("panic recovered: %v", err)
 		log.L.Error().
 			Stack().
 			Err(stackerr).

--- a/backend/cmd/pubsub-helper/main.go
+++ b/backend/cmd/pubsub-helper/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -172,6 +173,8 @@ func directusHook(projectID string, topicID string, event string, collection str
 		Data: data,
 	})
 
+	spew.Dump(projectID, topicID, event, collection, id)
+
 	_, err = msg.Get(ctx)
 	fmt.Printf("Sent: %v\n", err)
 }
@@ -240,6 +243,11 @@ func main() {
 	flag.Parse()
 	projectId := "btv-pubsub"
 	topicId := "export"
+
+	for i := 0; i < 2970; i++ {
+		directusHook(projectId, topicId, "items.update", "episode", strconv.Itoa(i))
+	}
+	return
 
 	err = godotenv.Load("backend/cmd/pubsub-helper/.env")
 	if err == nil {


### PR DESCRIPTION
The `fmt` package seems to have stripped the stacktrace from the error.