### PR TITLE
Do not return a nil error and a nil cursor at the same time

### DIFF
--- a/backend/cursors/item_cursor.go
+++ b/backend/cursors/item_cursor.go
@@ -22,7 +22,7 @@ func ParseItemCursor[K comparable](cursorString string) (*ItemCursor[K], error) 
 		return nil, err
 	}
 	if cursor.Keys == nil {
-		return nil, err
+		cursor.Keys = make([]K, 0)
 	}
 	return cursor, nil
 }


### PR DESCRIPTION
This should resolve the panic in https://linear.app/bcc-media/issue/BCC-71/

```golang
cursor, err = cursors.ParseItemCursor[int](episodeContext.Cursor.String)
if err != nil {
   return nil, err
}
cursor = cursor.CursorFor(intID)
```

Basically the first line returned `nil, nil`, so we did not bail out (correct), but the cursor in the last line was nil.