### PR TITLE
Add type to index

### DIFF
--- a/migrations/00337_update_collectionentries_constraint.sql
+++ b/migrations/00337_update_collectionentries_constraint.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+alter table users.collectionentries
+    drop constraint collectionentries_unique_key;
+
+alter table users.collectionentries
+    add constraint collectionentries_unique_key
+        unique (collection_id, item_id, type);
+
+-- +goose Down
+alter table users.collectionentries
+    drop constraint if exists collectionentries_unique_key;
+
+alter table users.collectionentries
+    add constraint collectionentries_unique_key
+        unique (collection_id, item_id);


### PR DESCRIPTION
I believe the issue was that you are able to add multiple types of content to the list and that content may share ID. So type must be considered in the uniqueness.