### PR TITLE
Feature/video player context headers

### DIFF
--- a/packages/video-player/package.json
+++ b/packages/video-player/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bccm-video-player",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "type": "commonjs",
     "types": "build/types/index.d.ts",
     "files": [

--- a/packages/video-player/src/btv-player/api/client.ts
+++ b/packages/video-player/src/btv-player/api/client.ts
@@ -2,6 +2,7 @@ export type ApiClientOptions = {
     tokenFactory: (() => Promise<string | null>) | null
     endpoint: string
     application?: string
+    headersFactory?: () => Record<string, string> | Promise<Record<string, string>>
 }
 
 export class ApiClient {
@@ -9,15 +10,21 @@ export class ApiClient {
     public application?: string
 
     private _tokens: null | (() => Promise<string | null>)
+    private _headers?: () => Record<string, string> | Promise<Record<string, string>>
 
-    constructor({ tokenFactory, endpoint, application }: ApiClientOptions) {
+    constructor({ tokenFactory, endpoint, application, headersFactory }: ApiClientOptions) {
         this._tokens = tokenFactory
         this.endpoint = endpoint
         this.application = application
+        this._headers = headersFactory
     }
 
     public getToken() {
         return this._tokens?.() ?? null
+    }
+
+    public async getHeaders(): Promise<Record<string, string>> {
+        return (await this._headers?.()) ?? {}
     }
 
     public static get default() {

--- a/packages/video-player/src/btv-player/api/episode.ts
+++ b/packages/video-player/src/btv-player/api/episode.ts
@@ -23,7 +23,9 @@ export const getEpisodeStreams = async (
 
     const token = await client.getToken()
 
-    const headers = {} as HeadersInit
+    const headers: Record<string, string> = {
+        ...(await client.getHeaders()),
+    }
 
     if (token) {
         headers["Authorization"] = "Bearer " + token

--- a/web/src/services/player.ts
+++ b/web/src/services/player.ts
@@ -3,13 +3,36 @@ import { PlayerFactory } from 'bccm-video-player'
 import 'bccm-video-player/css'
 import Auth from './auth'
 import { currentApp } from './app'
+import { current } from '@/services/language'
+import { getFeatureFlags } from '@/services/feature-flags'
+import { useSearch } from '@/utils/search'
 import { ref, watch } from 'vue'
+
+const { searchSessionId, sessionId } = useSearch()
+
+const buildHeaders = () => {
+    const headers: Record<string, string> = {
+        'Accept-Language': current.value.code,
+    }
+    const flags = getFeatureFlags()
+    if (flags) {
+        headers['X-Feature-Flags'] = flags
+    }
+    if (sessionId) {
+        headers['X-Session-Id'] = sessionId
+    }
+    if (searchSessionId.value) {
+        headers['X-Search-Session-Id'] = searchSessionId.value
+    }
+    return headers
+}
 
 const playerFactory = ref(
     new PlayerFactory({
         endpoint: config.api.url + '/query',
         tokenFactory: Auth.getToken,
         application: currentApp.value,
+        headersFactory: buildHeaders,
     })
 )
 
@@ -20,5 +43,6 @@ watch(currentApp, (app) => {
         endpoint: config.api.url + '/query',
         tokenFactory: Auth.getToken,
         application: app,
+        headersFactory: buildHeaders,
     })
 })


### PR DESCRIPTION
Currently the player does not send the `x-feature-flags` header. This makes it impossible to use server-side feature flags in the web player context.