### PR TITLE
feat(backend): expand contribution-type enum with new roles

### DIFF
--- a/backend/common/contributions.go
+++ b/backend/common/contributions.go
@@ -16,16 +16,34 @@ type Contribution struct {
 type ContributionType enum.Member[string]
 
 var (
-	ContributionTypeLyricist = ContributionType{"lyricist"}
-	ContributionTypeArranger = ContributionType{"arranger"}
-	ContributionTypeSinger   = ContributionType{"singer"}
-	ContributionTypeSpeaker  = ContributionType{"speaker"}
-	ContributionTypeUnknown  = ContributionType{"unknown"}
-	ContributionTypes        = enum.New(
+	ContributionTypeLyricist     = ContributionType{"lyricist"}
+	ContributionTypeArranger     = ContributionType{"arranger"}
+	ContributionTypeSinger       = ContributionType{"singer"}
+	ContributionTypeSpeaker      = ContributionType{"speaker"}
+	ContributionTypeComposer     = ContributionType{"composer"}
+	ContributionTypeSoloist      = ContributionType{"soloist"}
+	ContributionTypePerformer    = ContributionType{"performer"}
+	ContributionTypeTranslator   = ContributionType{"translator"}
+	ContributionTypeDirector     = ContributionType{"director"}
+	ContributionTypeProducer     = ContributionType{"producer"}
+	ContributionTypeScriptWriter = ContributionType{"scriptwriter"}
+	ContributionTypeActor        = ContributionType{"actor"}
+	ContributionTypeVoiceActor   = ContributionType{"voiceactor"}
+	ContributionTypeUnknown      = ContributionType{"unknown"}
+	ContributionTypes            = enum.New(
 		ContributionTypeLyricist,
 		ContributionTypeArranger,
 		ContributionTypeSinger,
 		ContributionTypeSpeaker,
+		ContributionTypeComposer,
+		ContributionTypeSoloist,
+		ContributionTypePerformer,
+		ContributionTypeTranslator,
+		ContributionTypeDirector,
+		ContributionTypeProducer,
+		ContributionTypeScriptWriter,
+		ContributionTypeActor,
+		ContributionTypeVoiceActor,
 		ContributionTypeUnknown,
 	)
 )

--- a/backend/graph/api/contributions.utils.go
+++ b/backend/graph/api/contributions.utils.go
@@ -21,6 +21,24 @@ func stringToContributionTypeCode(s string) model.ContributionTypeCode {
 		return model.ContributionTypeCodeSinger
 	case "speaker":
 		return model.ContributionTypeCodeSpeaker
+	case "composer":
+		return model.ContributionTypeCodeComposer
+	case "soloist":
+		return model.ContributionTypeCodeSoloist
+	case "performer":
+		return model.ContributionTypeCodePerformer
+	case "translator":
+		return model.ContributionTypeCodeTranslator
+	case "director":
+		return model.ContributionTypeCodeDirector
+	case "producer":
+		return model.ContributionTypeCodeProducer
+	case "scriptwriter":
+		return model.ContributionTypeCodeScriptwriter
+	case "actor":
+		return model.ContributionTypeCodeActor
+	case "voiceactor":
+		return model.ContributionTypeCodeVoiceactor
 	default:
 		return model.ContributionTypeCodeOther
 	}

--- a/backend/graph/api/generated/generated.go
+++ b/backend/graph/api/generated/generated.go
@@ -7360,6 +7360,15 @@ type ContextCollection {
     ARRANGER
     SINGER
     SPEAKER
+    COMPOSER
+    SOLOIST
+    PERFORMER
+    TRANSLATOR
+    DIRECTOR
+    PRODUCER
+    SCRIPTWRITER
+    ACTOR
+    VOICEACTOR
     OTHER
 }
 

--- a/backend/graph/api/model/models_gen.go
+++ b/backend/graph/api/model/models_gen.go
@@ -1797,11 +1797,20 @@ func (e CardSectionSize) MarshalJSON() ([]byte, error) {
 type ContributionTypeCode string
 
 const (
-	ContributionTypeCodeLyricist ContributionTypeCode = "LYRICIST"
-	ContributionTypeCodeArranger ContributionTypeCode = "ARRANGER"
-	ContributionTypeCodeSinger   ContributionTypeCode = "SINGER"
-	ContributionTypeCodeSpeaker  ContributionTypeCode = "SPEAKER"
-	ContributionTypeCodeOther    ContributionTypeCode = "OTHER"
+	ContributionTypeCodeLyricist     ContributionTypeCode = "LYRICIST"
+	ContributionTypeCodeArranger     ContributionTypeCode = "ARRANGER"
+	ContributionTypeCodeSinger       ContributionTypeCode = "SINGER"
+	ContributionTypeCodeSpeaker      ContributionTypeCode = "SPEAKER"
+	ContributionTypeCodeComposer     ContributionTypeCode = "COMPOSER"
+	ContributionTypeCodeSoloist      ContributionTypeCode = "SOLOIST"
+	ContributionTypeCodePerformer    ContributionTypeCode = "PERFORMER"
+	ContributionTypeCodeTranslator   ContributionTypeCode = "TRANSLATOR"
+	ContributionTypeCodeDirector     ContributionTypeCode = "DIRECTOR"
+	ContributionTypeCodeProducer     ContributionTypeCode = "PRODUCER"
+	ContributionTypeCodeScriptwriter ContributionTypeCode = "SCRIPTWRITER"
+	ContributionTypeCodeActor        ContributionTypeCode = "ACTOR"
+	ContributionTypeCodeVoiceactor   ContributionTypeCode = "VOICEACTOR"
+	ContributionTypeCodeOther        ContributionTypeCode = "OTHER"
 )
 
 var AllContributionTypeCode = []ContributionTypeCode{
@@ -1809,12 +1818,21 @@ var AllContributionTypeCode = []ContributionTypeCode{
 	ContributionTypeCodeArranger,
 	ContributionTypeCodeSinger,
 	ContributionTypeCodeSpeaker,
+	ContributionTypeCodeComposer,
+	ContributionTypeCodeSoloist,
+	ContributionTypeCodePerformer,
+	ContributionTypeCodeTranslator,
+	ContributionTypeCodeDirector,
+	ContributionTypeCodeProducer,
+	ContributionTypeCodeScriptwriter,
+	ContributionTypeCodeActor,
+	ContributionTypeCodeVoiceactor,
 	ContributionTypeCodeOther,
 }
 
 func (e ContributionTypeCode) IsValid() bool {
 	switch e {
-	case ContributionTypeCodeLyricist, ContributionTypeCodeArranger, ContributionTypeCodeSinger, ContributionTypeCodeSpeaker, ContributionTypeCodeOther:
+	case ContributionTypeCodeLyricist, ContributionTypeCodeArranger, ContributionTypeCodeSinger, ContributionTypeCodeSpeaker, ContributionTypeCodeComposer, ContributionTypeCodeSoloist, ContributionTypeCodePerformer, ContributionTypeCodeTranslator, ContributionTypeCodeDirector, ContributionTypeCodeProducer, ContributionTypeCodeScriptwriter, ContributionTypeCodeActor, ContributionTypeCodeVoiceactor, ContributionTypeCodeOther:
 		return true
 	}
 	return false

--- a/backend/graph/api/schema/persons.graphqls
+++ b/backend/graph/api/schema/persons.graphqls
@@ -3,6 +3,15 @@ enum ContributionTypeCode {
     ARRANGER
     SINGER
     SPEAKER
+    COMPOSER
+    SOLOIST
+    PERFORMER
+    TRANSLATOR
+    DIRECTOR
+    PRODUCER
+    SCRIPTWRITER
+    ACTOR
+    VOICEACTOR
     OTHER
 }
 

--- a/migrations/00339_add_contribution_types.sql
+++ b/migrations/00339_add_contribution_types.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+/**********************************************************/
+/*** SCRIPT AUTHOR: Matjaz Debelak (matjaz@debelak.org) ***/
+/***    CREATED ON: 2026-05-11T00:00:00.000Z            ***/
+/**********************************************************/
+
+UPDATE "public"."directus_fields" SET "options" = '{"choices":[{"text":"Speaker","value":"speaker"},{"text":"Lyricist","value":"lyricist"},{"text":"Arranger","value":"arranger"},{"text":"Singer","value":"singer"},{"text":"Composer","value":"composer"},{"text":"Soloist","value":"soloist"},{"text":"Performer","value":"performer"},{"text":"Translator","value":"translator"},{"text":"Director","value":"director"},{"text":"Producer","value":"producer"},{"text":"Script Writer","value":"scriptwriter"},{"text":"Actor","value":"actor"},{"text":"Voice Actor","value":"voiceactor"}],"icon":"category"}' WHERE "id" = 3023;
+
+-- +goose Down
+/**********************************************************/
+/*** SCRIPT AUTHOR: Matjaz Debelak (matjaz@debelak.org) ***/
+/***    CREATED ON: 2026-05-11T00:00:00.000Z            ***/
+/**********************************************************/
+
+UPDATE "public"."directus_fields" SET "options" = '{"choices":[{"text":"Speaker","value":"speaker"},{"text":"Lyricist","value":"lyricist"},{"text":"Arranger","value":"arranger"},{"text":"Singer","value":"singer"}],"icon":"category"}' WHERE "id" = 3023;


### PR DESCRIPTION
Adds composer, soloist, performer, translator, director, producer, scriptwriter, actor, and voiceactor to the contribution-type enum across the Directus dropdown, Go enum, GraphQL schema, and DB→GraphQL conversion.