### PR TITLE
feat(mediaitems): add copyright_holder field and expose on Episode

### DIFF
--- a/backend/common/items.go
+++ b/backend/common/items.go
@@ -151,8 +151,9 @@ type Episode struct {
 	ExtraDescription LocaleString `json:"extraDescription"`
 	NumberInTitle    bool         `json:"numberInTitle"`
 
-	ContentType null.String `json:"contentType"`
-	Audience    null.String `json:"audience"`
+	ContentType       null.String   `json:"contentType"`
+	Audience          null.String   `json:"audience"`
+	CopyrightHolderID uuid.NullUUID `json:"copyrightHolderId"`
 }
 
 // GetKey returns the key for this item

--- a/backend/graph/api/episodes.resolvers.go
+++ b/backend/graph/api/episodes.resolvers.go
@@ -467,6 +467,19 @@ func (r *episodeResolver) Contributors(ctx context.Context, obj *model.Episode) 
 	return contributors, nil
 }
 
+// CopyrightHolder is the resolver for the copyrightHolder field.
+func (r *episodeResolver) CopyrightHolder(ctx context.Context, obj *model.Episode) (*model.Person, error) {
+	e, err := r.Loaders.EpisodeLoader.Get(ctx, utils.AsInt(obj.ID))
+	if err != nil || e == nil || !e.CopyrightHolderID.Valid {
+		return nil, err
+	}
+	person, err := r.Loaders.PersonLoader.Get(ctx, e.CopyrightHolderID.UUID)
+	if err != nil || person == nil {
+		return nil, err
+	}
+	return model.PersonFrom(ctx, person), nil
+}
+
 // Next is the resolver for the next field.
 func (r *episodeResolver) Next(ctx context.Context, obj *model.Episode, limit *int) ([]*model.Episode, error) {
 	next, err := r.getNextEpisodes(ctx, obj.ID, limit)

--- a/backend/graph/api/generated/generated.go
+++ b/backend/graph/api/generated/generated.go
@@ -334,6 +334,7 @@ type ComplexityRoot struct {
 		Chapters              func(childComplexity int) int
 		Context               func(childComplexity int) int
 		Contributors          func(childComplexity int) int
+		CopyrightHolder       func(childComplexity int) int
 		Cursor                func(childComplexity int) int
 		Description           func(childComplexity int) int
 		Duration              func(childComplexity int) int
@@ -1210,6 +1211,7 @@ type EpisodeResolver interface {
 	ShareRestriction(ctx context.Context, obj *model.Episode) (model.ShareRestriction, error)
 	InMyList(ctx context.Context, obj *model.Episode) (bool, error)
 	Contributors(ctx context.Context, obj *model.Episode) ([]*model.Contributor, error)
+	CopyrightHolder(ctx context.Context, obj *model.Episode) (*model.Person, error)
 	Next(ctx context.Context, obj *model.Episode, limit *int) ([]*model.Episode, error)
 	Cursor(ctx context.Context, obj *model.Episode) (string, error)
 }
@@ -2467,6 +2469,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Episode.Contributors(childComplexity), true
+
+	case "Episode.copyrightHolder":
+		if e.complexity.Episode.CopyrightHolder == nil {
+			break
+		}
+
+		return e.complexity.Episode.CopyrightHolder(childComplexity), true
 
 	case "Episode.cursor":
 		if e.complexity.Episode.Cursor == nil {
@@ -7072,6 +7081,7 @@ type Episode implements CollectionItem & PlaylistItem & MediaItem {
     shareRestriction: ShareRestriction! @goField(forceResolver: true)
     inMyList: Boolean! @goField(forceResolver: true)
     contributors: [Contributor!]! @goField(forceResolver: true)
+    copyrightHolder: Person @goField(forceResolver: true)
 
     """
     Should probably be used asynchronously, and retrieved separately from the episode, as it can be slow in some cases (a few db requests can occur)
@@ -17462,6 +17472,8 @@ func (ec *executionContext) fieldContext_Chapter_episode(_ context.Context, fiel
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -21285,6 +21297,63 @@ func (ec *executionContext) fieldContext_Episode_contributors(_ context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _Episode_copyrightHolder(ctx context.Context, field graphql.CollectedField, obj *model.Episode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Episode_copyrightHolder(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Episode().CopyrightHolder(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Person)
+	fc.Result = res
+	return ec.marshalOPerson2ᚖgithubᚗcomᚋbccᚑcodeᚋbccᚑmediaᚑplatformᚋbackendᚋgraphᚋapiᚋmodelᚐPerson(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Episode_copyrightHolder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Episode",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Person_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Person_name(ctx, field)
+			case "type":
+				return ec.fieldContext_Person_type(ctx, field)
+			case "image":
+				return ec.fieldContext_Person_image(ctx, field)
+			case "contributionTypes":
+				return ec.fieldContext_Person_contributionTypes(ctx, field)
+			case "contributionContentTypes":
+				return ec.fieldContext_Person_contributionContentTypes(ctx, field)
+			case "contributions":
+				return ec.fieldContext_Person_contributions(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Person", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Episode_next(ctx context.Context, field graphql.CollectedField, obj *model.Episode) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Episode_next(ctx, field)
 	if err != nil {
@@ -21400,6 +21469,8 @@ func (ec *executionContext) fieldContext_Episode_next(ctx context.Context, field
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -21897,6 +21968,8 @@ func (ec *executionContext) fieldContext_EpisodeCalendarEntry_episode(_ context.
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -22331,6 +22404,8 @@ func (ec *executionContext) fieldContext_EpisodePagination_items(_ context.Conte
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -27367,6 +27442,8 @@ func (ec *executionContext) fieldContext_Lesson_defaultEpisode(_ context.Context
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -30179,6 +30256,8 @@ func (ec *executionContext) fieldContext_MutationRoot_setEpisodeProgress(ctx con
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -34378,6 +34457,8 @@ func (ec *executionContext) fieldContext_QueryRoot_episode(ctx context.Context, 
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -34515,6 +34596,8 @@ func (ec *executionContext) fieldContext_QueryRoot_episodes(ctx context.Context,
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -37803,6 +37886,8 @@ func (ec *executionContext) fieldContext_Season_defaultEpisode(_ context.Context
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -41499,6 +41584,8 @@ func (ec *executionContext) fieldContext_Show_defaultEpisode(_ context.Context, 
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -46955,6 +47042,8 @@ func (ec *executionContext) fieldContext_VideoTask_episode(_ context.Context, fi
 				return ec.fieldContext_Episode_inMyList(ctx, field)
 			case "contributors":
 				return ec.fieldContext_Episode_contributors(ctx, field)
+			case "copyrightHolder":
+				return ec.fieldContext_Episode_copyrightHolder(ctx, field)
 			case "next":
 				return ec.fieldContext_Episode_next(ctx, field)
 			case "cursor":
@@ -53423,6 +53512,39 @@ func (ec *executionContext) _Episode(ctx context.Context, sel ast.SelectionSet, 
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "copyrightHolder":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Episode_copyrightHolder(ctx, field, obj)
 				return res
 			}
 
@@ -65540,6 +65662,13 @@ func (ec *executionContext) marshalOPage2ᚖgithubᚗcomᚋbccᚑcodeᚋbccᚑme
 		return graphql.Null
 	}
 	return ec._Page(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOPerson2ᚖgithubᚗcomᚋbccᚑcodeᚋbccᚑmediaᚑplatformᚋbackendᚋgraphᚋapiᚋmodelᚐPerson(ctx context.Context, sel ast.SelectionSet, v *model.Person) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Person(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOQuestionPagination2ᚖgithubᚗcomᚋbccᚑcodeᚋbccᚑmediaᚑplatformᚋbackendᚋgraphᚋapiᚋmodelᚐQuestionPagination(ctx context.Context, sel ast.SelectionSet, v *model.QuestionPagination) graphql.Marshaler {

--- a/backend/graph/api/model/models_gen.go
+++ b/backend/graph/api/model/models_gen.go
@@ -515,6 +515,7 @@ type Episode struct {
 	ShareRestriction      ShareRestriction       `json:"shareRestriction"`
 	InMyList              bool                   `json:"inMyList"`
 	Contributors          []*Contributor         `json:"contributors"`
+	CopyrightHolder       *Person                `json:"copyrightHolder,omitempty"`
 	// Should probably be used asynchronously, and retrieved separately from the episode, as it can be slow in some cases (a few db requests can occur)
 	Next   []*Episode `json:"next"`
 	Cursor string     `json:"cursor"`

--- a/backend/graph/api/schema/episodes.graphqls
+++ b/backend/graph/api/schema/episodes.graphqls
@@ -52,6 +52,7 @@ type Episode implements CollectionItem & PlaylistItem & MediaItem {
     shareRestriction: ShareRestriction! @goField(forceResolver: true)
     inMyList: Boolean! @goField(forceResolver: true)
     contributors: [Contributor!]! @goField(forceResolver: true)
+    copyrightHolder: Person @goField(forceResolver: true)
 
     """
     Should probably be used asynchronously, and retrieved separately from the episode, as it can be slow in some cases (a few db requests can occur)

--- a/backend/sqlc/episode-queries.go
+++ b/backend/sqlc/episode-queries.go
@@ -60,6 +60,7 @@ func (q *Queries) mapToEpisodes(episodes []getEpisodesRow) []common.Episode {
 			Duration:              int(e.Duration.ValueOrZero()),
 			Audience:              e.Audience,
 			ContentType:           e.ContentType,
+			CopyrightHolderID:     e.CopyrightHolderID,
 			TagIDs: lo.Map(e.TagIds, func(id int32, _ int) int {
 				return int(id)
 			}),
@@ -116,6 +117,7 @@ func (q *Queries) mapListToEpisodes(episodes []listEpisodesRow) []common.Episode
 			Duration:              int(e.Duration.ValueOrZero()),
 			Audience:              e.Audience,
 			ContentType:           e.ContentType,
+			CopyrightHolderID:     e.CopyrightHolderID,
 			TagIDs: lo.Map(e.TagIds, func(id int32, _ int) int {
 				return int(id)
 			}),

--- a/backend/sqlc/episodes.sql.go
+++ b/backend/sqlc/episodes.sql.go
@@ -415,7 +415,8 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type
+       mi.content_type,
+       mi.copyright_holder_id
 FROM episodes e
          LEFT JOIN mediaitems_by_episodes_v2($1::int[]) mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id
@@ -460,6 +461,7 @@ type getEpisodesRow struct {
 	Agerating             string                `db:"agerating" json:"agerating"`
 	Audience              null_v4.String        `db:"audience" json:"audience"`
 	ContentType           null_v4.String        `db:"content_type" json:"contentType"`
+	CopyrightHolderID     uuid.NullUUID         `db:"copyright_holder_id" json:"copyrightHolderId"`
 }
 
 func (q *Queries) getEpisodes(ctx context.Context, dollar_1 []int32) ([]getEpisodesRow, error) {
@@ -504,6 +506,7 @@ func (q *Queries) getEpisodes(ctx context.Context, dollar_1 []int32) ([]getEpiso
 			&i.Agerating,
 			&i.Audience,
 			&i.ContentType,
+			&i.CopyrightHolderID,
 		); err != nil {
 			return nil, err
 		}
@@ -615,7 +618,8 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type
+       mi.content_type,
+       mi.copyright_holder_id
 FROM episodes e
          LEFT JOIN mediaitems_view_v2 mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id
@@ -658,6 +662,7 @@ type listEpisodesRow struct {
 	Agerating             string                `db:"agerating" json:"agerating"`
 	Audience              null_v4.String        `db:"audience" json:"audience"`
 	ContentType           null_v4.String        `db:"content_type" json:"contentType"`
+	CopyrightHolderID     uuid.NullUUID         `db:"copyright_holder_id" json:"copyrightHolderId"`
 }
 
 func (q *Queries) listEpisodes(ctx context.Context) ([]listEpisodesRow, error) {
@@ -702,6 +707,7 @@ func (q *Queries) listEpisodes(ctx context.Context) ([]listEpisodesRow, error) {
 			&i.Agerating,
 			&i.Audience,
 			&i.ContentType,
+			&i.CopyrightHolderID,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/sqlc/mediaitems.sql.go
+++ b/backend/sqlc/mediaitems.sql.go
@@ -16,7 +16,7 @@ import (
 )
 
 const getMediaItemByID = `-- name: GetMediaItemByID :one
-SELECT id, user_created, date_created, user_updated, date_updated, label, title, description, type, asset_id, parent_episode_id, parent_starts_at, parent_ends_at, published_at, production_date, parent_id, content_type, audience, agerating_code, translations_required, timedmetadata_from_asset, available_from, available_to, primary_episode_id FROM mediaitems WHERE id = $1::uuid
+SELECT id, user_created, date_created, user_updated, date_updated, label, title, description, type, asset_id, parent_episode_id, parent_starts_at, parent_ends_at, published_at, production_date, parent_id, content_type, audience, agerating_code, translations_required, timedmetadata_from_asset, available_from, available_to, primary_episode_id, copyright_holder_id FROM mediaitems WHERE id = $1::uuid
 `
 
 func (q *Queries) GetMediaItemByID(ctx context.Context, id uuid.UUID) (Mediaitem, error) {
@@ -47,6 +47,7 @@ func (q *Queries) GetMediaItemByID(ctx context.Context, id uuid.UUID) (Mediaitem
 		&i.AvailableFrom,
 		&i.AvailableTo,
 		&i.PrimaryEpisodeID,
+		&i.CopyrightHolderID,
 	)
 	return i, err
 }

--- a/backend/sqlc/models.go
+++ b/backend/sqlc/models.go
@@ -1093,6 +1093,7 @@ type Mediaitem struct {
 	AvailableFrom          null_v4.Time    `db:"available_from" json:"availableFrom"`
 	AvailableTo            null_v4.Time    `db:"available_to" json:"availableTo"`
 	PrimaryEpisodeID       null_v4.Int     `db:"primary_episode_id" json:"primaryEpisodeId"`
+	CopyrightHolderID      uuid.NullUUID   `db:"copyright_holder_id" json:"copyrightHolderId"`
 }
 
 type MediaitemsAsset struct {
@@ -1195,6 +1196,7 @@ type MediaitemsViewV2 struct {
 	AgeratingCode        null_v4.String  `db:"agerating_code" json:"ageratingCode"`
 	Audience             null_v4.String  `db:"audience" json:"audience"`
 	ContentType          null_v4.String  `db:"content_type" json:"contentType"`
+	CopyrightHolderID    uuid.NullUUID   `db:"copyright_holder_id" json:"copyrightHolderId"`
 	ProductionDate       time.Time       `db:"production_date" json:"productionDate"`
 	PublishedAt          time.Time       `db:"published_at" json:"publishedAt"`
 	TranslationsRequired bool            `db:"translations_required" json:"translationsRequired"`

--- a/migrations/00341_mediaitem_copyright_holder.sql
+++ b/migrations/00341_mediaitem_copyright_holder.sql
@@ -1,0 +1,316 @@
+-- +goose Up
+
+ALTER TABLE IF EXISTS "public"."mediaitems"
+    ADD COLUMN IF NOT EXISTS "copyright_holder_id" uuid NULL;
+
+ALTER TABLE "public"."mediaitems"
+    ADD CONSTRAINT "mediaitems_copyright_holder_id_foreign"
+    FOREIGN KEY (copyright_holder_id) REFERENCES persons (id) ON DELETE RESTRICT;
+
+DROP VIEW IF EXISTS mediaitems_view_v2 CASCADE;
+
+CREATE OR REPLACE VIEW mediaitems_view_v2
+            (id, assets, asset_id, original_title, original_description, title, description, images, parent_id,
+             parent_episode_id, parent_starts_at, parent_ends_at, available_from, available_to, label, agerating_code,
+             audience, content_type, copyright_holder_id, production_date, published_at, translations_required,
+             date_updated, duration, asset_date_updated, tag_ids)
+AS
+SELECT mi.id,
+       ma.assets,
+       mi.asset_id,
+       mi.title                                                                         AS original_title,
+       mi.description                                                                   AS original_description,
+       COALESCE(titles.title, '{}'::json)                                               AS title,
+       COALESCE(descriptions.description, '{}'::json)                                   AS description,
+       COALESCE(images.images, '{}'::json)                                              AS images,
+       mi.parent_id,
+       mi.parent_episode_id,
+       mi.parent_starts_at,
+       mi.parent_ends_at,
+       COALESCE(mi.available_from, '1900-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone  AS available_from,
+       COALESCE(mi.available_to, '3000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone    AS available_to,
+       mi.label,
+       mi.agerating_code,
+       mi.audience,
+       mi.content_type,
+       mi.copyright_holder_id,
+       COALESCE(mi.production_date, '2000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone AS production_date,
+       COALESCE(mi.published_at, '2000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone    AS published_at,
+       mi.translations_required,
+       COALESCE(mi.date_created, mi.date_updated)                                       AS date_updated,
+       a.duration,
+       a.date_updated                                                                   AS asset_date_updated,
+       tags.tags::int[]                                                                 AS tag_ids
+FROM mediaitems mi
+         LEFT JOIN (SELECT ts.mediaitems_id,
+                           json_object_agg(ts.languages_code, ts.title) AS title
+                    FROM mediaitems_translations ts
+                    GROUP BY ts.mediaitems_id) titles ON titles.mediaitems_id = mi.id
+         LEFT JOIN (SELECT ts.mediaitems_id,
+                           json_object_agg(ts.languages_code, ts.description) AS description
+                    FROM mediaitems_translations ts
+                    GROUP BY ts.mediaitems_id) descriptions ON descriptions.mediaitems_id = mi.id
+         LEFT JOIN (SELECT simg.mediaitems_id,
+                           json_agg(json_build_object('style', img.style, 'language', img.language, 'filename_disk',
+                                                      df.filename_disk)) AS images
+                    FROM mediaitems_styledimages simg
+                             JOIN styledimages img ON img.id = simg.styledimages_id
+                             JOIN directus_files df ON img.file = df.id
+                    GROUP BY simg.mediaitems_id) images ON images.mediaitems_id = mi.id
+         LEFT JOIN (SELECT ma_1.mediaitems_id,
+                           json_object_agg(ma_1.language, ma_1.assets_id) AS assets
+                    FROM mediaitems_assets ma_1
+                    GROUP BY ma_1.mediaitems_id) ma ON ma.mediaitems_id = mi.id
+         LEFT JOIN assets a ON a.id = mi.asset_id
+         LEFT JOIN (SELECT t.mediaitems_id,
+                           array_agg(t.tags_id) AS tags
+                    FROM mediaitems_tags t
+                    GROUP BY t.mediaitems_id) tags ON tags.mediaitems_id = mi.id;
+
+GRANT SELECT ON mediaitems_view_v2 TO api;
+GRANT SELECT ON mediaitems_view_v2 TO background_worker;
+GRANT SELECT ON mediaitems_view_v2 TO onsite_backup;
+GRANT SELECT ON mediaitems_view_v2 TO staging_sync;
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION mediaitems_by_episodes_v2(episodeids integer[]) RETURNS SETOF mediaitems_view_v2
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    RETURN QUERY (WITH mids AS (
+        SELECT mediaitem_id FROM episodes WHERE episodes.id = ANY(episodeids)
+    )
+                  SELECT mi.id,
+                         COALESCE(ma.assets, '{}'::json)                                                  AS assets,
+                         mi.asset_id,
+                         mi.title                                                                         AS original_title,
+                         mi.description                                                                   AS original_description,
+                         COALESCE(titles.title, '{}'::json)                                               AS title,
+                         COALESCE(descriptions.description, '{}'::json)                                   AS description,
+                         COALESCE(images.images, '{}'::json)                                              AS images,
+                         mi.parent_id,
+                         mi.parent_episode_id,
+                         mi.parent_starts_at,
+                         mi.parent_ends_at,
+                         COALESCE(mi.available_from, '1900-01-01 00:00:00'::timestamp without time zone)  AS available_from,
+                         COALESCE(mi.available_to, '3000-01-01 00:00:00'::timestamp without time zone)    AS available_to,
+                         mi.label,
+                         mi.agerating_code,
+                         mi.audience,
+                         mi.content_type,
+                         mi.copyright_holder_id,
+                         COALESCE(mi.production_date, '2000-01-01 00:00:00'::timestamp without time zone) AS production_date,
+                         COALESCE(mi.published_at, '2000-01-01 00:00:00'::timestamp without time zone)    AS published_at,
+                         mi.translations_required,
+                         COALESCE(mi.date_created, mi.date_updated)                                       AS date_updated,
+                         a.duration,
+                         a.date_updated                                                                   AS asset_date_updated,
+                         tags.tags                                                                        AS tag_ids
+                  FROM mediaitems mi
+                           JOIN episodes e ON e.mediaitem_id = mi.id
+                           LEFT JOIN (SELECT ts.mediaitems_id,
+                                             json_object_agg(ts.languages_code, ts.title) AS title
+                                      FROM mediaitems_translations ts
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ts.mediaitems_id) titles ON titles.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT ts.mediaitems_id,
+                                             json_object_agg(ts.languages_code, ts.description) AS description
+                                      FROM mediaitems_translations ts
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ts.mediaitems_id) descriptions ON descriptions.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT simg.mediaitems_id,
+                                             json_agg(json_build_object('style', img.style, 'language', img.language, 'filename_disk',
+                                                                        df.filename_disk)) AS images
+                                      FROM mediaitems_styledimages simg
+                                               JOIN styledimages img ON img.id = simg.styledimages_id
+                                               JOIN directus_files df ON img.file = df.id
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY simg.mediaitems_id) images ON images.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT ma_1.mediaitems_id,
+                                             json_object_agg(ma_1.language, ma_1.assets_id) AS assets
+                                      FROM mediaitems_assets ma_1
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ma_1.mediaitems_id) ma ON ma.mediaitems_id = mi.id
+                           LEFT JOIN assets a ON a.id = mi.asset_id
+                           LEFT JOIN (SELECT t.mediaitems_id,
+                                             array_agg(t.tags_id) AS tags
+                                      FROM mediaitems_tags t
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY t.mediaitems_id) tags ON tags.mediaitems_id = mi.id
+                  WHERE e.id = ANY(episodeids));
+END;
+$$;
+-- +goose StatementEnd
+
+GRANT EXECUTE ON FUNCTION mediaitems_by_episodes_v2(integer[]) TO api;
+
+INSERT INTO "public"."directus_fields" ("id", "collection", "field", "special", "interface", "options", "display",
+                                        "display_options", "readonly", "hidden", "sort", "width", "translations",
+                                        "note", "conditions", "required", "group", "validation", "validation_message")
+VALUES (3087, 'mediaitems', 'copyright_holder_id', 'm2o', 'select-dropdown-m2o', '{
+  "template": "{{name}}"
+}', 'related-values', '{
+  "template": "{{name}}"
+}', false, false, NULL, 'half', NULL, NULL, NULL, false, 'metadata', NULL, NULL);
+
+SELECT setval(pg_get_serial_sequence('"public"."directus_fields"', 'id'), max("id"), true)
+FROM "public"."directus_fields";
+
+INSERT INTO "public"."directus_relations" ("id", "many_collection", "many_field", "one_collection", "one_field",
+                                           "one_collection_field", "one_allowed_collections", "junction_field",
+                                           "sort_field", "one_deselect_action")
+VALUES (483, 'mediaitems', 'copyright_holder_id', 'persons', NULL, NULL, NULL, NULL, NULL, 'no action');
+
+SELECT setval(pg_get_serial_sequence('"public"."directus_relations"', 'id'), max("id"), true)
+FROM "public"."directus_relations";
+
+
+-- +goose Down
+
+DELETE FROM "public"."directus_relations" WHERE "id" = 483;
+
+DELETE FROM "public"."directus_fields" WHERE "id" = 3087;
+
+DROP FUNCTION IF EXISTS mediaitems_by_episodes_v2(integer[]);
+DROP VIEW IF EXISTS mediaitems_view_v2 CASCADE;
+
+CREATE OR REPLACE VIEW mediaitems_view_v2
+            (id, assets, asset_id, original_title, original_description, title, description, images, parent_id,
+             parent_episode_id, parent_starts_at, parent_ends_at, available_from, available_to, label, agerating_code,
+             audience, content_type, production_date, published_at, translations_required, date_updated, duration,
+             asset_date_updated, tag_ids)
+AS
+SELECT mi.id,
+       ma.assets,
+       mi.asset_id,
+       mi.title                                                                         AS original_title,
+       mi.description                                                                   AS original_description,
+       COALESCE(titles.title, '{}'::json)                                               AS title,
+       COALESCE(descriptions.description, '{}'::json)                                   AS description,
+       COALESCE(images.images, '{}'::json)                                              AS images,
+       mi.parent_id,
+       mi.parent_episode_id,
+       mi.parent_starts_at,
+       mi.parent_ends_at,
+       COALESCE(mi.available_from, '1900-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone  AS available_from,
+       COALESCE(mi.available_to, '3000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone    AS available_to,
+       mi.label,
+       mi.agerating_code,
+       mi.audience,
+       mi.content_type,
+       COALESCE(mi.production_date, '2000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone AS production_date,
+       COALESCE(mi.published_at, '2000-01-01 00:00:00'::timestamp without time zone)::timestamp without time zone    AS published_at,
+       mi.translations_required,
+       COALESCE(mi.date_created, mi.date_updated)                                       AS date_updated,
+       a.duration,
+       a.date_updated                                                                   AS asset_date_updated,
+       tags.tags::int[]                                                                 AS tag_ids
+FROM mediaitems mi
+         LEFT JOIN (SELECT ts.mediaitems_id,
+                           json_object_agg(ts.languages_code, ts.title) AS title
+                    FROM mediaitems_translations ts
+                    GROUP BY ts.mediaitems_id) titles ON titles.mediaitems_id = mi.id
+         LEFT JOIN (SELECT ts.mediaitems_id,
+                           json_object_agg(ts.languages_code, ts.description) AS description
+                    FROM mediaitems_translations ts
+                    GROUP BY ts.mediaitems_id) descriptions ON descriptions.mediaitems_id = mi.id
+         LEFT JOIN (SELECT simg.mediaitems_id,
+                           json_agg(json_build_object('style', img.style, 'language', img.language, 'filename_disk',
+                                                      df.filename_disk)) AS images
+                    FROM mediaitems_styledimages simg
+                             JOIN styledimages img ON img.id = simg.styledimages_id
+                             JOIN directus_files df ON img.file = df.id
+                    GROUP BY simg.mediaitems_id) images ON images.mediaitems_id = mi.id
+         LEFT JOIN (SELECT ma_1.mediaitems_id,
+                           json_object_agg(ma_1.language, ma_1.assets_id) AS assets
+                    FROM mediaitems_assets ma_1
+                    GROUP BY ma_1.mediaitems_id) ma ON ma.mediaitems_id = mi.id
+         LEFT JOIN assets a ON a.id = mi.asset_id
+         LEFT JOIN (SELECT t.mediaitems_id,
+                           array_agg(t.tags_id) AS tags
+                    FROM mediaitems_tags t
+                    GROUP BY t.mediaitems_id) tags ON tags.mediaitems_id = mi.id;
+
+GRANT SELECT ON mediaitems_view_v2 TO api;
+GRANT SELECT ON mediaitems_view_v2 TO background_worker;
+GRANT SELECT ON mediaitems_view_v2 TO onsite_backup;
+GRANT SELECT ON mediaitems_view_v2 TO staging_sync;
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION mediaitems_by_episodes_v2(episodeids integer[]) RETURNS SETOF mediaitems_view_v2
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    RETURN QUERY (WITH mids AS (
+        SELECT mediaitem_id FROM episodes WHERE episodes.id = ANY(episodeids)
+    )
+                  SELECT mi.id,
+                         COALESCE(ma.assets, '{}'::json)                                                  AS assets,
+                         mi.asset_id,
+                         mi.title                                                                         AS original_title,
+                         mi.description                                                                   AS original_description,
+                         COALESCE(titles.title, '{}'::json)                                               AS title,
+                         COALESCE(descriptions.description, '{}'::json)                                   AS description,
+                         COALESCE(images.images, '{}'::json)                                              AS images,
+                         mi.parent_id,
+                         mi.parent_episode_id,
+                         mi.parent_starts_at,
+                         mi.parent_ends_at,
+                         COALESCE(mi.available_from, '1900-01-01 00:00:00'::timestamp without time zone)  AS available_from,
+                         COALESCE(mi.available_to, '3000-01-01 00:00:00'::timestamp without time zone)    AS available_to,
+                         mi.label,
+                         mi.agerating_code,
+                         mi.audience,
+                         mi.content_type,
+                         COALESCE(mi.production_date, '2000-01-01 00:00:00'::timestamp without time zone) AS production_date,
+                         COALESCE(mi.published_at, '2000-01-01 00:00:00'::timestamp without time zone)    AS published_at,
+                         mi.translations_required,
+                         COALESCE(mi.date_created, mi.date_updated)                                       AS date_updated,
+                         a.duration,
+                         a.date_updated                                                                   AS asset_date_updated,
+                         tags.tags                                                                        AS tag_ids
+                  FROM mediaitems mi
+                           JOIN episodes e ON e.mediaitem_id = mi.id
+                           LEFT JOIN (SELECT ts.mediaitems_id,
+                                             json_object_agg(ts.languages_code, ts.title) AS title
+                                      FROM mediaitems_translations ts
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ts.mediaitems_id) titles ON titles.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT ts.mediaitems_id,
+                                             json_object_agg(ts.languages_code, ts.description) AS description
+                                      FROM mediaitems_translations ts
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ts.mediaitems_id) descriptions ON descriptions.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT simg.mediaitems_id,
+                                             json_agg(json_build_object('style', img.style, 'language', img.language, 'filename_disk',
+                                                                        df.filename_disk)) AS images
+                                      FROM mediaitems_styledimages simg
+                                               JOIN styledimages img ON img.id = simg.styledimages_id
+                                               JOIN directus_files df ON img.file = df.id
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY simg.mediaitems_id) images ON images.mediaitems_id = mi.id
+                           LEFT JOIN (SELECT ma_1.mediaitems_id,
+                                             json_object_agg(ma_1.language, ma_1.assets_id) AS assets
+                                      FROM mediaitems_assets ma_1
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY ma_1.mediaitems_id) ma ON ma.mediaitems_id = mi.id
+                           LEFT JOIN assets a ON a.id = mi.asset_id
+                           LEFT JOIN (SELECT t.mediaitems_id,
+                                             array_agg(t.tags_id) AS tags
+                                      FROM mediaitems_tags t
+                                      WHERE mediaitems_id IN (SELECT * FROM mids)
+                                      GROUP BY t.mediaitems_id) tags ON tags.mediaitems_id = mi.id
+                  WHERE e.id = ANY(episodeids));
+END;
+$$;
+-- +goose StatementEnd
+
+GRANT EXECUTE ON FUNCTION mediaitems_by_episodes_v2(integer[]) TO api;
+
+ALTER TABLE IF EXISTS "public"."mediaitems"
+    DROP CONSTRAINT IF EXISTS "mediaitems_copyright_holder_id_foreign";
+
+ALTER TABLE IF EXISTS "public"."mediaitems"
+    DROP COLUMN IF EXISTS "copyright_holder_id";

--- a/queries/episodes.sql
+++ b/queries/episodes.sql
@@ -34,7 +34,8 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type
+       mi.content_type,
+       mi.copyright_holder_id
 FROM episodes e
          LEFT JOIN mediaitems_view_v2 mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id
@@ -80,7 +81,8 @@ SELECT e.id,
        mi.asset_date_updated,
        COALESCE(mi.agerating_code, e.agerating_code, s.agerating_code, 'A') as agerating,
        mi.audience,
-       mi.content_type
+       mi.content_type,
+       mi.copyright_holder_id
 FROM episodes e
          LEFT JOIN mediaitems_by_episodes_v2($1::int[]) mi ON mi.id = e.mediaitem_id
          LEFT JOIN ts ON e.id = ts.episodes_id


### PR DESCRIPTION
Adds a nullable copyright_holder_id FK on mediaitems (ON DELETE RESTRICT to prevent removing persons with active copyright references) and surfaces it on the GraphQL Episode type as copyrightHolder: Person.