### PR TITLE
chore(security): harden public API surface

### DIFF
--- a/backend/cmd/api/handlers.go
+++ b/backend/cmd/api/handlers.go
@@ -15,10 +15,12 @@ import (
 	"github.com/bcc-code/bcc-media-platform/backend/analytics"
 	"github.com/bcc-code/bcc-media-platform/backend/auth0"
 	"github.com/bcc-code/bcc-media-platform/backend/email"
+	gqlextension "github.com/99designs/gqlgen/graphql/handler/extension"
 	graphadmin "github.com/bcc-code/bcc-media-platform/backend/graph/admin"
 	graphadmingenerated "github.com/bcc-code/bcc-media-platform/backend/graph/admin/generated"
 	graphapi "github.com/bcc-code/bcc-media-platform/backend/graph/api"
 	graphapigenerated "github.com/bcc-code/bcc-media-platform/backend/graph/api/generated"
+	apiextension "github.com/bcc-code/bcc-media-platform/backend/graph/extension"
 	"github.com/bcc-code/bcc-media-platform/backend/graph/gqltracer"
 	graphpublic "github.com/bcc-code/bcc-media-platform/backend/graph/public"
 	graphpublicgenerated "github.com/bcc-code/bcc-media-platform/backend/graph/public/generated"
@@ -100,6 +102,8 @@ func graphqlHandler(
 	// Resolver is in the resolver.go file
 	h := handler.NewDefaultServer(graphapigenerated.NewExecutableSchema(graphapigenerated.Config{Resolvers: &resolver}))
 	h.Use(tracer)
+	h.Use(gqlextension.FixedComplexityLimit(1000))
+	h.Use(apiextension.DepthLimit{Max: 15})
 
 	h.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
 		// Wrap the panic error with a stack trace using pkg/errors
@@ -153,6 +157,8 @@ func publicGraphqlHandler(loaders *loaders.BatchLoaders) gin.HandlerFunc {
 	// Resolver is in the resolver.go file
 	h := handler.NewDefaultServer(graphpublicgenerated.NewExecutableSchema(graphpublicgenerated.Config{Resolvers: &resolver}))
 	h.Use(tracer)
+	h.Use(gqlextension.FixedComplexityLimit(500))
+	h.Use(apiextension.DepthLimit{Max: 10})
 
 	return func(c *gin.Context) {
 		h.ServeHTTP(c.Writer, c.Request)
@@ -169,6 +175,8 @@ func adminGraphqlHandler(config envConfig, db *sql.DB, queries *sqlc.Queries, lo
 	// NewExecutableSchema and Config are in the generated.go file
 	// Resolver is in the resolver.go file
 	h := handler.NewDefaultServer(graphadmingenerated.NewExecutableSchema(graphadmingenerated.Config{Resolvers: &resolver}))
+	h.Use(gqlextension.FixedComplexityLimit(5000))
+	h.Use(apiextension.DepthLimit{Max: 20})
 
 	directusSecret := config.Secrets.Directus
 	if directusSecret == "" {

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -298,7 +298,17 @@ func main() {
 	r.GET("/versionz", version.GinHandler)
 
 	if os.Getenv("PPROF") == "TRUE" {
-		pprof.Register(r, "debug/pprof")
+		// Mount pprof on a separate engine bound to localhost so it isn't
+		// reachable through the public load balancer. Operators reach it via
+		// `kubectl port-forward` or an in-pod shell.
+		debugR := gin.New()
+		debugR.Use(gin.Recovery())
+		pprof.Register(debugR, "debug/pprof")
+		go func() {
+			if err := debugR.Run("127.0.0.1:6060"); err != nil {
+				log.L.Warn().Err(err).Msg("pprof server stopped")
+			}
+		}()
 	}
 
 	r.GET("/.well-known/jwks.json", <-jwkChan)

--- a/backend/graph/extension/depth_limit.go
+++ b/backend/graph/extension/depth_limit.go
@@ -1,0 +1,75 @@
+// Package extension contains gqlgen handler extensions used by the API.
+package extension
+
+import (
+	"context"
+	"errors"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+// DepthLimit rejects operations whose selection set nests deeper than Max.
+// Fragment spreads and inline fragments are followed but do not themselves
+// count as a depth level — only field selections do, matching how a server
+// actually expands work.
+type DepthLimit struct {
+	Max int
+}
+
+var _ interface {
+	graphql.OperationContextMutator
+	graphql.HandlerExtension
+} = DepthLimit{}
+
+func (DepthLimit) ExtensionName() string { return "DepthLimit" }
+
+func (d DepthLimit) Validate(graphql.ExecutableSchema) error {
+	if d.Max <= 0 {
+		return errors.New("DepthLimit.Max must be > 0")
+	}
+	return nil
+}
+
+func (d DepthLimit) MutateOperationContext(_ context.Context, opCtx *graphql.OperationContext) *gqlerror.Error {
+	if opCtx == nil || opCtx.Operation == nil {
+		return nil
+	}
+	fragments := map[string]*ast.FragmentDefinition{}
+	if opCtx.Doc != nil {
+		for _, f := range opCtx.Doc.Fragments {
+			fragments[f.Name] = f
+		}
+	}
+	depth := maxSelectionDepth(opCtx.Operation.SelectionSet, 1, fragments)
+	if depth > d.Max {
+		return gqlerror.Errorf("operation exceeds maximum depth of %d (got %d)", d.Max, depth)
+	}
+	return nil
+}
+
+func maxSelectionDepth(sel ast.SelectionSet, depth int, fragments map[string]*ast.FragmentDefinition) int {
+	best := depth
+	for _, s := range sel {
+		switch v := s.(type) {
+		case *ast.Field:
+			if len(v.SelectionSet) > 0 {
+				if c := maxSelectionDepth(v.SelectionSet, depth+1, fragments); c > best {
+					best = c
+				}
+			}
+		case *ast.InlineFragment:
+			if c := maxSelectionDepth(v.SelectionSet, depth, fragments); c > best {
+				best = c
+			}
+		case *ast.FragmentSpread:
+			if f, ok := fragments[v.Name]; ok {
+				if c := maxSelectionDepth(f.SelectionSet, depth, fragments); c > best {
+					best = c
+				}
+			}
+		}
+	}
+	return best
+}

--- a/backend/graph/extension/depth_limit_test.go
+++ b/backend/graph/extension/depth_limit_test.go
@@ -1,0 +1,62 @@
+package extension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+)
+
+func parseOp(t *testing.T, src string) *graphql.OperationContext {
+	t.Helper()
+	doc, perr := parser.ParseQuery(&ast.Source{Input: src})
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	if len(doc.Operations) == 0 {
+		t.Fatalf("no operations")
+	}
+	return &graphql.OperationContext{
+		Doc:       doc,
+		Operation: doc.Operations[0],
+	}
+}
+
+func TestDepthLimit_AllowsUnderLimit(t *testing.T) {
+	opCtx := parseOp(t, `{ a { b { c } } }`) // depth 3
+	err := DepthLimit{Max: 3}.MutateOperationContext(context.Background(), opCtx)
+	assert.Nil(t, err)
+}
+
+func TestDepthLimit_RejectsOverLimit(t *testing.T) {
+	opCtx := parseOp(t, `{ a { b { c { d } } } }`) // depth 4
+	err := DepthLimit{Max: 3}.MutateOperationContext(context.Background(), opCtx)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Message, "exceeds maximum depth")
+}
+
+func TestDepthLimit_CountsThroughFragmentSpread(t *testing.T) {
+	// Total nesting is 4 (a > b > c > d) even though spread out across fragments.
+	opCtx := parseOp(t, `
+		{ a { b { ...F } } }
+		fragment F on T { c { d } }
+	`)
+	err := DepthLimit{Max: 3}.MutateOperationContext(context.Background(), opCtx)
+	assert.NotNil(t, err)
+}
+
+func TestDepthLimit_CountsThroughInlineFragment(t *testing.T) {
+	// Inline fragments must not be a free pass past the limit.
+	opCtx := parseOp(t, `{ a { ... on T { b { c { d } } } } }`) // depth 4
+	err := DepthLimit{Max: 3}.MutateOperationContext(context.Background(), opCtx)
+	assert.NotNil(t, err)
+}
+
+func TestDepthLimit_Validate(t *testing.T) {
+	assert.Error(t, DepthLimit{Max: 0}.Validate(nil))
+	assert.Error(t, DepthLimit{Max: -1}.Validate(nil))
+	assert.NoError(t, DepthLimit{Max: 1}.Validate(nil))
+}

--- a/backend/items/collection/filter.go
+++ b/backend/items/collection/filter.go
@@ -128,39 +128,19 @@ func GetSQLForFilter(args FilterParams) *squirrel.SelectBuilder {
 	// Convert % value to a [-1, 1] float
 	deboostFactor := args.Filter.DeboostFactor / 100.0
 
-	// --- Randomization/Deboost Logic ---
-	//
-	// This CASE expression calculates a pseudo-random value for each row, with optional deboosting if a specific tag is present.
-	//
-	// Variables:
-	//   - args.Filter.DeboostTag:     The tag (string) that triggers deboosting if present in t.tags (array)
-	//   - args.Filter.DeboostFactor:  The deboost factor (float64) to apply if the tag is present
-	//   - randomFunc:                 The SQL expression/function that produces a random value per row (e.g. random() or seeded value)
-	//
-	// Logic:
-	//   - If the row's tags contain DeboostTag AND DeboostFactor > 0:
-	//       - If the random value is less than DeboostFactor, increment the random value by 1 (pushes it to the end)
-	//       - Otherwise, keep the random value as is
-	//   - Else: just use the random value
-	//
-	// The result is aliased as 'r' and used for randomized ordering with deboost applied to tagged items.
-	selectFields = append(
-		selectFields,
-		fmt.Sprintf(
-			`CASE
-				WHEN t.tags @> ARRAY['%s']::varchar[] /* DeboostTag */ AND %f > 0.0 /* DeboostFactor */
-					THEN CASE WHEN random() < 1.0 - %f /* DeboostFactor */ THEN random() ELSE random() + 1 END
-				ELSE random()
-			END AS r`,
-			args.Filter.DeboostTag, // Tag to check for deboost
-			deboostFactor,          // Deboost factor threshold
-			deboostFactor,          // Deboost factor threshold
-		),
-	)
+	// Randomization with optional per-tag deboost. DeboostTag and DeboostFactor
+	// are parameterized to keep CMS-authored values from breaking out of the
+	// SQL literal.
+	const deboostExpr = `CASE
+			WHEN t.tags @> ARRAY[?]::varchar[] AND ? > 0.0
+				THEN CASE WHEN random() < 1.0 - ? THEN random() ELSE random() + 1 END
+			ELSE random()
+		END AS r`
 
 	q := squirrel.StatementBuilder.
 		PlaceholderFormat(squirrel.Dollar).
 		Select(selectFields...).
+		Column(squirrel.Expr(deboostExpr, args.Filter.DeboostTag, deboostFactor, deboostFactor)).
 		From(from).
 		Where(query.Filter)
 

--- a/backend/items/collection/filter_test.go
+++ b/backend/items/collection/filter_test.go
@@ -192,12 +192,41 @@ func TestGetSQLForFilter_WithDeboost(t *testing.T) {
 	result := GetSQLForFilter(params)
 
 	assert.NotNil(t, result)
-	sql, _, _ := result.ToSql()
+	sql, args, _ := result.ToSql()
 
-	// Verify the SQL contains deboost logic
-	assert.Contains(t, sql, "WHEN t.tags @> ARRAY['preview']::varchar[] /* DeboostTag */ AND 0.500000 > 0.0 /* DeboostFactor */")
-	assert.Contains(t, sql, "THEN CASE WHEN random() < 1.0 - 0.500000 /* DeboostFactor */ THEN random() ELSE random() + 1 END")
+	// The CASE expression must use placeholders, not interpolated values.
+	assert.Contains(t, sql, "ARRAY[$1]::varchar[]")
+	assert.Contains(t, sql, "THEN CASE WHEN random() < 1.0 - $3")
 	assert.Contains(t, sql, "ELSE random()")
+	assert.Equal(t, "preview", args[0])
+	assert.Equal(t, 0.5, args[1])
+	assert.Equal(t, 0.5, args[2])
+}
+
+func TestGetSQLForFilter_DeboostTagEscaping(t *testing.T) {
+	// Regression: a DeboostTag containing SQL meta-characters must be passed
+	// through as a parameter, not interpolated into the SQL string.
+	filterJSON := `{"==": [{"var": "type"}, "episode"]}`
+
+	injection := "x'] OR 1=1; --"
+	params := FilterParams{
+		Filter: common.Filter{
+			Filter:        json.RawMessage(filterJSON),
+			DeboostTag:    injection,
+			DeboostFactor: 10.0,
+		},
+	}
+
+	result := GetSQLForFilter(params)
+	assert.NotNil(t, result)
+	sql, args, err := result.ToSql()
+	assert.NoError(t, err)
+
+	// The injection payload must NOT appear in the generated SQL.
+	assert.NotContains(t, sql, injection)
+	assert.NotContains(t, sql, "OR 1=1")
+	// It must appear unchanged in the args slice.
+	assert.Equal(t, injection, args[0])
 }
 
 func TestGetSQLForFilter_WithLimit(t *testing.T) {


### PR DESCRIPTION
- Mount pprof on an internal 127.0.0.1:6060 engine instead of the public router so heap/goroutine/CPU profiles aren't reachable through the load balancer when PPROF=TRUE.
- Add gqlgen FixedComplexityLimit and a new DepthLimit extension (backend/graph/extension) on /query, /admin, and /public to bound GraphQL DoS surface; thresholds are conservative starting values to be tuned from real-traffic stats.
- Parameterize Filter.DeboostTag in the collection filter SQL builder so CMS-authored tags can't break out of the array literal; existing test updated and a regression test asserts injection payloads land in the args slice, not the SQL string.