### PR TITLE
fix(translations): repair sync dedup, fallback, and empty-shadowing bugs

### DIFF
--- a/backend/common/locale-map.go
+++ b/backend/common/locale-map.go
@@ -6,10 +6,19 @@ var DefaultLanguages = []string{"en", "no"}
 // LocaleMap is a map of strings to nullable strings
 type LocaleMap[T any] map[string]T
 
+// withDefaults returns a new slice of the requested languages followed by the
+// DefaultLanguages. It never mutates the input slice, which is important
+// because the caller's slice (e.g. the one cached on the request context) is
+// shared across concurrently-running resolvers.
+func withDefaults(languages []string) []string {
+	out := make([]string, 0, len(languages)+len(DefaultLanguages))
+	out = append(out, languages...)
+	return append(out, DefaultLanguages...)
+}
+
 // Get from a translation map based on the fallbacks
 func (localeMap LocaleMap[T]) Get(languages []string) T {
-	languages = append(languages, DefaultLanguages...) // We force the DefaultLanguages as the last languages regardless if they have been specified before already
-	for _, l := range languages {
+	for _, l := range withDefaults(languages) {
 		if val, ok := localeMap[l]; ok {
 			return val
 		}
@@ -26,8 +35,7 @@ func (localeMap LocaleMap[T]) Get(languages []string) T {
 
 // GetValueOrNil returns either the value for selected languages or nil
 func (localeMap LocaleMap[T]) GetValueOrNil(languages []string) *T {
-	languages = append(languages, DefaultLanguages...) // We force the DefaultLanguages as the last languages regardless if they have been specified before already
-	for _, l := range languages {
+	for _, l := range withDefaults(languages) {
 		if val, ok := localeMap[l]; ok {
 			return &val
 		}

--- a/backend/common/locale-string.go
+++ b/backend/common/locale-string.go
@@ -14,9 +14,8 @@ type nnLocaleString LocaleMap[string]
 
 // Get from a translation map based on the fallbacks
 func (localeString LocaleString) Get(languages []string) string {
-	languages = append(languages, DefaultLanguages...) // We force the DefaultLanguages as the last languages regardless if they have been specified before already
-	for _, l := range languages {
-		if val, ok := localeString[l]; ok && val.Valid {
+	for _, l := range withDefaults(languages) {
+		if val, ok := localeString[l]; ok && val.Valid && val.String != "" {
 			return val.String
 		}
 	}
@@ -31,9 +30,8 @@ func (localeString LocaleString) Get(languages []string) string {
 
 // GetValueOrNil returns either the value for selected languages or nil
 func (localeString LocaleString) GetValueOrNil(languages []string) *string {
-	languages = append(languages, DefaultLanguages...) // We force the DefaultLanguages as the last languages regardless if they have been specified before already
-	for _, l := range languages {
-		if val, ok := localeString[l]; ok && val.Valid {
+	for _, l := range withDefaults(languages) {
+		if val, ok := localeString[l]; ok && val.Valid && val.String != "" {
 			return &val.String
 		}
 	}

--- a/backend/common/locale-string_test.go
+++ b/backend/common/locale-string_test.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"sync"
+	"testing"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+// TestLocaleStringGetEmptyFallsThrough verifies that a valid-but-empty
+// translation does not shadow a populated fallback language (B2).
+func TestLocaleStringGetEmptyFallsThrough(t *testing.T) {
+	ls := LocaleString{
+		"de": null.StringFrom(""),
+		"en": null.StringFrom("Welcome"),
+	}
+
+	if got := ls.Get([]string{"de"}); got != "Welcome" {
+		t.Errorf("Get([de]) = %q, want %q", got, "Welcome")
+	}
+
+	if got := ls.GetValueOrNil([]string{"de"}); got == nil || *got != "Welcome" {
+		t.Errorf("GetValueOrNil([de]) = %v, want pointer to %q", got, "Welcome")
+	}
+}
+
+// TestLocaleStringGetAllEmpty verifies the final fallback is still "" when no
+// language has a non-empty value.
+func TestLocaleStringGetAllEmpty(t *testing.T) {
+	ls := LocaleString{"de": null.StringFrom(""), "en": null.StringFrom("")}
+	if got := ls.Get([]string{"de"}); got != "" {
+		t.Errorf("Get([de]) = %q, want empty string", got)
+	}
+}
+
+// TestLocaleStringGetDoesNotMutateInput guards against Get/GetValueOrNil
+// appending DefaultLanguages onto the caller's slice (B1). The request-scoped
+// languages slice is shared across concurrent resolvers, so it must never be
+// mutated.
+func TestLocaleStringGetDoesNotMutateInput(t *testing.T) {
+	ls := LocaleString{"no": null.StringFrom("Hei")}
+
+	// A slice with spare capacity is the dangerous case for append-aliasing.
+	languages := make([]string, 1, 8)
+	languages[0] = "de"
+
+	_ = ls.Get(languages)
+	_ = ls.GetValueOrNil(languages)
+
+	if len(languages) != 1 || languages[0] != "de" {
+		t.Fatalf("input slice was mutated: %v (len %d)", languages, len(languages))
+	}
+}
+
+// TestLocaleStringGetConcurrent runs Get concurrently against the same shared
+// languages slice; combined with `go test -race` this catches the data race
+// from mutating the shared backing array (B1).
+func TestLocaleStringGetConcurrent(t *testing.T) {
+	ls := LocaleString{"en": null.StringFrom("Welcome"), "no": null.StringFrom("Hei")}
+	languages := make([]string, 1, 8)
+	languages[0] = "de"
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			if got := ls.Get(languages); got != "Welcome" {
+				t.Errorf("Get = %q, want %q", got, "Welcome")
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/backend/sqlc/calendar.sql.go
+++ b/backend/sqlc/calendar.sql.go
@@ -21,7 +21,6 @@ FROM calendarentries_translations et
     JOIN calendarentries e ON e.id = et.calendarentries_id
 WHERE et.languages_code ='no'
   AND et.date_updated > $1
-  AND e.date_updated > $1
   AND e.status = ANY ('{published,unlisted}')
 `
 

--- a/backend/sqlc/models.go
+++ b/backend/sqlc/models.go
@@ -878,31 +878,6 @@ type EpisodesTranslation struct {
 	DateUpdated      time.Time      `db:"date_updated" json:"dateUpdated"`
 }
 
-type EpisodesUsergroup struct {
-	EpisodesID     int32          `db:"episodes_id" json:"episodesId"`
-	ID             int32          `db:"id" json:"id"`
-	Type           null_v4.String `db:"type" json:"type"`
-	UsergroupsCode string         `db:"usergroups_code" json:"usergroupsCode"`
-	DateCreated    time.Time      `db:"date_created" json:"dateCreated"`
-	DateUpdated    null_v4.Time   `db:"date_updated" json:"dateUpdated"`
-}
-
-type EpisodesUsergroupsDownload struct {
-	EpisodesID     int32     `db:"episodes_id" json:"episodesId"`
-	ID             int32     `db:"id" json:"id"`
-	UsergroupsCode string    `db:"usergroups_code" json:"usergroupsCode"`
-	DateCreated    time.Time `db:"date_created" json:"dateCreated"`
-	DateUpdated    time.Time `db:"date_updated" json:"dateUpdated"`
-}
-
-type EpisodesUsergroupsEarlyaccess struct {
-	EpisodesID     int32     `db:"episodes_id" json:"episodesId"`
-	ID             int32     `db:"id" json:"id"`
-	UsergroupsCode string    `db:"usergroups_code" json:"usergroupsCode"`
-	DateCreated    time.Time `db:"date_created" json:"dateCreated"`
-	DateUpdated    time.Time `db:"date_updated" json:"dateUpdated"`
-}
-
 type Event struct {
 	DateCreated null_v4.Time  `db:"date_created" json:"dateCreated"`
 	DateUpdated null_v4.Time  `db:"date_updated" json:"dateUpdated"`

--- a/backend/sqlc/translations.sql.go
+++ b/backend/sqlc/translations.sql.go
@@ -7,58 +7,11 @@ package sqlc
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
 	null_v4 "gopkg.in/guregu/null.v4"
 )
-
-const getCalendarEntryTranslatable = `-- name: GetCalendarEntryTranslatable :many
-SELECT et.id,
-       calendarentries_id                                            as parent_id,
-       languages_code                                                as language,
-       json_build_object('title', title, 'description', description) as values
-FROM calendarentries_translations et
-         JOIN events e ON e.id = et.calendarentries_id
-WHERE et.languages_code = 'no'
-AND et.date_updated > $1
-`
-
-type GetCalendarEntryTranslatableRow struct {
-	ID       int32           `db:"id" json:"id"`
-	ParentID int32           `db:"parent_id" json:"parentId"`
-	Language string          `db:"language" json:"language"`
-	Values   json.RawMessage `db:"values" json:"values"`
-}
-
-func (q *Queries) GetCalendarEntryTranslatable(ctx context.Context, dateUpdated time.Time) ([]GetCalendarEntryTranslatableRow, error) {
-	rows, err := q.db.QueryContext(ctx, getCalendarEntryTranslatable, dateUpdated)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetCalendarEntryTranslatableRow
-	for rows.Next() {
-		var i GetCalendarEntryTranslatableRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.ParentID,
-			&i.Language,
-			&i.Values,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
 
 const getEpisodeTranslatable = `-- name: GetEpisodeTranslatable :many
 WITH episodes AS (SELECT e.id
@@ -404,38 +357,6 @@ func (q *Queries) GetShowTranslatable(ctx context.Context, dateUpdated time.Time
 	for rows.Next() {
 		var i GetShowTranslatableRow
 		if err := rows.Scan(&i.ID, &i.Title, &i.Description); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getTranslationsHash = `-- name: GetTranslationsHash :many
-SELECT collection, hash, last_sent, date_updated FROM translations_hash WHERE hash = $1
-`
-
-func (q *Queries) GetTranslationsHash(ctx context.Context, hash []byte) ([]TranslationsHash, error) {
-	rows, err := q.db.QueryContext(ctx, getTranslationsHash, hash)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []TranslationsHash
-	for rows.Next() {
-		var i TranslationsHash
-		if err := rows.Scan(
-			&i.Collection,
-			&i.Hash,
-			&i.LastSent,
-			&i.DateUpdated,
-		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/backend/translations/collection_handlers_export.go
+++ b/backend/translations/collection_handlers_export.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/bcc-code/bcc-media-platform/backend/common"
+	"github.com/bcc-code/bcc-media-platform/backend/log"
 	"gopkg.in/guregu/null.v4"
 	"time"
 )
@@ -283,7 +284,10 @@ func (s *Service) getDataForSurveys(ctx context.Context) ([]common.TranslationDa
 
 	for _, t := range data {
 		questions := []TitleWithId{}
-		_ = json.Unmarshal(t.Questions, &questions)
+		if err := json.Unmarshal(t.Questions, &questions); err != nil {
+			log.L.Error().Err(err).Str("id", t.ID.String()).Msg("Failed to unmarshal survey questions; skipping")
+			continue
+		}
 
 		value := SurveyTranslations{
 			Title:       t.Title,
@@ -313,7 +317,10 @@ func (s *Service) getDataForStudyQuestions(ctx context.Context) ([]common.Transl
 
 	for _, t := range data {
 		answers := []TitleWithId{}
-		_ = json.Unmarshal(t.Answers, &answers)
+		if err := json.Unmarshal(t.Answers, &answers); err != nil {
+			log.L.Error().Err(err).Str("id", t.ID.String()).Msg("Failed to unmarshal study question answers; skipping")
+			continue
+		}
 
 		value := StudyQuestions{
 			Question:    t.Question.ValueOrZero(),

--- a/backend/translations/collection_handlers_import.go
+++ b/backend/translations/collection_handlers_import.go
@@ -12,18 +12,22 @@ import (
 func (s *Service) updateAchievementGroups(ctx context.Context, data []common.TranslationData) []error {
 	errs := make([]error, 0)
 	for _, d := range data {
-		value := &TitleDescriptionTranslation{}
+		// Achievement groups are exported as TitleTranslation (title only),
+		// so decode the same shape here to avoid losing the title to a
+		// type mismatch.
+		value := &TitleTranslation{}
 		err := json.Unmarshal(d.Value, value)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateAchievementGroupTranslation(ctx, sqlc.UpdateAchievementGroupTranslationParams{
-			Language:    d.Language,
-			ItemID:      utils.AsUuid(d.ID),
-			Description: value.Description,
-			Title:       null.StringFrom(value.Title),
-		})
+		if err := s.queries.UpdateAchievementGroupTranslation(ctx, sqlc.UpdateAchievementGroupTranslationParams{
+			Language: d.Language,
+			ItemID:   utils.AsUuid(d.ID),
+			Title:    value.Title,
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -42,12 +46,14 @@ func (s *Service) updateAchievements(ctx context.Context, data []common.Translat
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateAchievementTranslation(ctx, sqlc.UpdateAchievementTranslationParams{
+		if err := s.queries.UpdateAchievementTranslation(ctx, sqlc.UpdateAchievementTranslationParams{
 			Language:    d.Language,
 			ItemID:      utils.AsUuid(d.ID),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -67,19 +73,23 @@ func (s *Service) updateStudyQuestions(ctx context.Context, data []common.Transl
 			continue
 		}
 
-		s.queries.UpdateTaskTranslation(ctx, sqlc.UpdateTaskTranslationParams{
+		if err := s.queries.UpdateTaskTranslation(ctx, sqlc.UpdateTaskTranslationParams{
 			Language:    d.Language,
 			ItemID:      utils.AsUuid(d.ID),
 			Title:       null.StringFrom(value.Question),
 			Description: value.Description,
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 
 		for _, answer := range value.Answers {
-			s.queries.UpdateAlternativeTranslation(ctx, sqlc.UpdateAlternativeTranslationParams{
+			if err := s.queries.UpdateAlternativeTranslation(ctx, sqlc.UpdateAlternativeTranslationParams{
 				Language: d.Language,
 				ItemID:   utils.AsUuid(answer.ID),
 				Title:    null.StringFrom(answer.Title),
-			})
+			}); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 
@@ -100,12 +110,14 @@ func (s *Service) updateCalendarEntries(ctx context.Context, data []common.Trans
 			continue
 		}
 
-		s.queries.UpdateCalendarEntryTranslation(ctx, sqlc.UpdateCalendarEntryTranslationParams{
+		if err := s.queries.UpdateCalendarEntryTranslation(ctx, sqlc.UpdateCalendarEntryTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -124,12 +136,14 @@ func (s *Service) updateEpisodes(ctx context.Context, data []common.TranslationD
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateEpisodeTranslation(ctx, sqlc.UpdateEpisodeTranslationParams{
+		if err := s.queries.UpdateEpisodeTranslation(ctx, sqlc.UpdateEpisodeTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -148,12 +162,14 @@ func (s *Service) updateEvents(ctx context.Context, data []common.TranslationDat
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateEventTranslation(ctx, sqlc.UpdateEventTranslationParams{
+		if err := s.queries.UpdateEventTranslation(ctx, sqlc.UpdateEventTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -166,18 +182,20 @@ func (s *Service) updateEvents(ctx context.Context, data []common.TranslationDat
 func (s *Service) updateFAQCategories(ctx context.Context, data []common.TranslationData) []error {
 	errs := make([]error, 0)
 	for _, d := range data {
-		value := &TitleDescriptionTranslation{}
+		// FAQ categories are exported as TitleTranslation (title only).
+		value := &TitleTranslation{}
 		err := json.Unmarshal(d.Value, value)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateFAQCategoryTranslation(ctx, sqlc.UpdateFAQCategoryTranslationParams{
-			Language:    d.Language,
-			ItemID:      utils.AsUuid(d.ID),
-			Description: value.Description,
-			Title:       null.StringFrom(value.Title),
-		})
+		if err := s.queries.UpdateFAQCategoryTranslation(ctx, sqlc.UpdateFAQCategoryTranslationParams{
+			Language: d.Language,
+			ItemID:   utils.AsUuid(d.ID),
+			Title:    value.Title,
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -196,12 +214,14 @@ func (s *Service) updateFAQs(ctx context.Context, data []common.TranslationData)
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateFAQTranslation(ctx, sqlc.UpdateFAQTranslationParams{
+		if err := s.queries.UpdateFAQTranslation(ctx, sqlc.UpdateFAQTranslationParams{
 			Language: d.Language,
 			ItemID:   utils.AsUuid(d.ID),
 			Question: value.Question,
 			Answer:   value.Answer,
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -220,12 +240,14 @@ func (s *Service) updateGames(ctx context.Context, data []common.TranslationData
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateGameTranslation(ctx, sqlc.UpdateGameTranslationParams{
+		if err := s.queries.UpdateGameTranslation(ctx, sqlc.UpdateGameTranslationParams{
 			Language:    d.Language,
 			ItemID:      utils.AsUuid(d.ID),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -244,12 +266,14 @@ func (s *Service) updateLessons(ctx context.Context, data []common.TranslationDa
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateLessonTranslation(ctx, sqlc.UpdateLessonTranslationParams{
+		if err := s.queries.UpdateLessonTranslation(ctx, sqlc.UpdateLessonTranslationParams{
 			Language:    d.Language,
 			ItemID:      utils.AsUuid(d.ID),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -268,12 +292,14 @@ func (s *Service) updateLinks(ctx context.Context, data []common.TranslationData
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateLinkTranslation(ctx, sqlc.UpdateLinkTranslationParams{
+		if err := s.queries.UpdateLinkTranslation(ctx, sqlc.UpdateLinkTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description.ValueOrZero(),
 			Title:       value.Title,
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -292,12 +318,14 @@ func (s *Service) updateMediaItems(ctx context.Context, data []common.Translatio
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateMediaItemTranslation(ctx, sqlc.UpdateMediaItemTranslationParams{
+		if err := s.queries.UpdateMediaItemTranslation(ctx, sqlc.UpdateMediaItemTranslationParams{
 			Language:    d.Language,
 			ItemID:      utils.AsUuid(d.ID),
 			Description: value.Description,
 			Title:       value.Title,
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -317,12 +345,14 @@ func (s *Service) updatePages(ctx context.Context, data []common.TranslationData
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdatePageTranslation(ctx, sqlc.UpdatePageTranslationParams{
+		if err := s.queries.UpdatePageTranslation(ctx, sqlc.UpdatePageTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -341,12 +371,14 @@ func (s *Service) updatePlaylists(ctx context.Context, data []common.Translation
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdatePlaylistTranslation(ctx, sqlc.UpdatePlaylistTranslationParams{
+		if err := s.queries.UpdatePlaylistTranslation(ctx, sqlc.UpdatePlaylistTranslationParams{
 			Language:    d.Language,
 			ItemID:      utils.AsUuid(d.ID),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -365,12 +397,14 @@ func (s *Service) updateSeasons(ctx context.Context, data []common.TranslationDa
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateSeasonTranslation(ctx, sqlc.UpdateSeasonTranslationParams{
+		if err := s.queries.UpdateSeasonTranslation(ctx, sqlc.UpdateSeasonTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -389,12 +423,14 @@ func (s *Service) updateSections(ctx context.Context, data []common.TranslationD
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateSectionTranslation(ctx, sqlc.UpdateSectionTranslationParams{
+		if err := s.queries.UpdateSectionTranslation(ctx, sqlc.UpdateSectionTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -413,12 +449,14 @@ func (s *Service) updateShows(ctx context.Context, data []common.TranslationData
 			errs = append(errs, err)
 			continue
 		}
-		s.queries.UpdateShowTranslation(ctx, sqlc.UpdateShowTranslationParams{
+		if err := s.queries.UpdateShowTranslation(ctx, sqlc.UpdateShowTranslationParams{
 			Language:    d.Language,
 			ItemID:      int32(utils.AsInt(d.ID)),
 			Description: value.Description,
 			Title:       null.StringFrom(value.Title),
-		})
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -449,9 +487,10 @@ func (s *Service) updateSurveys(ctx context.Context, data []common.TranslationDa
 
 		for _, q := range value.Questions {
 			err = s.queries.UpdateSurveyQuestionTranslation(ctx, sqlc.UpdateSurveyQuestionTranslationParams{
-				Language: d.Language,
-				ItemID:   utils.AsUuid(q.ID),
-				Title:    null.StringFrom(q.Title),
+				Language:    d.Language,
+				ItemID:      utils.AsUuid(q.ID),
+				Title:       null.StringFrom(q.Title),
+				Description: q.Description,
 			})
 			if err != nil {
 				errs = append(errs, err)

--- a/backend/translations/service.go
+++ b/backend/translations/service.go
@@ -163,7 +163,11 @@ func (s *Service) sendToProviderIfNeeded(ctx context.Context, collection Transla
 
 	log.L.Debug().Str("collection", collection.Value).Str("hash", hash).Send()
 
-	// This does not work in prod (but it does locally). If you can figure out what's wrong, you get a cookie!
+	// Only the per-collection 30-minute window decides whether to send. The
+	// previous global GetTranslationsHash check (lookup by hash across all
+	// collections, with no time window) permanently blocked re-sending any
+	// payload whose hash had ever been recorded - which is why it stopped
+	// sending in prod once the table was populated.
 	res, err := s.queries.ShouldSendTranslations(ctx, sqlc.ShouldSendTranslationsParams{
 		Collection: collection.Value,
 		Hash:       []byte(hash),
@@ -174,19 +178,6 @@ func (s *Service) sendToProviderIfNeeded(ctx context.Context, collection Transla
 
 	if !res {
 		log.L.Debug().Str("collection", collection.Value).Msg("Skipping sending to provider")
-		return nil
-	}
-
-	hashes, err := s.queries.GetTranslationsHash(ctx, []byte(hash))
-	if err != nil {
-		return err
-	}
-
-	if len(hashes) > 0 {
-		log.L.Debug().Str("collection", collection.Value).Msg("Skipping sending to provider as it has already been sent")
-		for _, hash := range hashes {
-			log.L.Debug().Str("hash", string(hash.Hash)).Str("collection", hash.Collection).Msg("Skipping sending to provider as it has already been sent")
-		}
 		return nil
 	}
 

--- a/backend/translations/service_test.go
+++ b/backend/translations/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bcc-code/bcc-media-platform/backend/translations"
 	"github.com/bcc-code/bcc-media-platform/backend/utils/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestShowSeasonEpisodeTranslations(t *testing.T) {
@@ -71,6 +72,44 @@ func TestShowSeasonEpisodeTranslations(t *testing.T) {
 
 	err = service.SendCollectionToTranslation(ctx, translations.CollectionEpisodes)
 	assert.NoError(t, err)
+
+	tsMock.AssertExpectations(t)
+}
+
+// TestTranslationsResentAfterWindow guards the A1 fix: an unchanged payload is
+// deduplicated only by the per-collection 30-minute window. Once that window
+// elapses it must be sent again (re-notifying translators). The previous
+// global GetTranslationsHash check blocked this permanently once the hash had
+// ever been recorded - which is why sending silently stopped in prod.
+func TestTranslationsResentAfterWindow(t *testing.T) {
+	log.ConfigureGlobalLogger(zerolog.DebugLevel)
+
+	db := testutils.NewDB(t)
+	q := sqlc.New(db)
+
+	ctx := context.Background()
+
+	err := testutils.InsertDefaults(ctx, q)
+	assert.NoError(t, err)
+
+	testutils.CreateRandomShow(t, ctx, q)
+
+	tsMock := Mocktranslations.MockTranslationsProvider{}
+	tsMock.EXPECT().SendToTranslation(ctx, "shows", mock.Anything).Return(nil).Twice()
+
+	service := translations.NewService(q, &tsMock)
+
+	// First send records the hash.
+	assert.NoError(t, service.SendCollectionToTranslation(ctx, translations.CollectionShows))
+	// Immediate re-send is skipped (still inside the 30-minute window).
+	assert.NoError(t, service.SendCollectionToTranslation(ctx, translations.CollectionShows))
+
+	// Backdate last_sent so the dedup window has elapsed.
+	_, err = db.ExecContext(ctx, "UPDATE translations_hash SET last_sent = NOW() - INTERVAL '31 minutes' WHERE collection = 'shows'")
+	assert.NoError(t, err)
+
+	// Now the same payload must be sent again.
+	assert.NoError(t, service.SendCollectionToTranslation(ctx, translations.CollectionShows))
 
 	tsMock.AssertExpectations(t)
 }

--- a/backend/translations/types.go
+++ b/backend/translations/types.go
@@ -42,6 +42,7 @@ type EpisodesTranslations struct {
 }
 
 type TitleWithId struct {
-	Title string
-	ID    string `json:"@id"`
+	Title       string
+	Description null.String `json:"description,omitempty"`
+	ID          string      `json:"@id"`
 }

--- a/backend/utils/accept-language.go
+++ b/backend/utils/accept-language.go
@@ -24,20 +24,22 @@ func ParseAcceptLanguage(acceptLanguage string) []string {
 		trimmedLangQStr := strings.Trim(langQStr, " ")
 		langQ := strings.Split(trimmedLangQStr, ";")
 
-		if len(langQ) == 0 {
-			lqs = append(lqs, "en") // Fallback to english
-			return lqs
-		}
-
 		lq := langQ[0]
 		lq2 := strings.FieldsFunc(lq, func(char rune) bool {
 			return char == '-' || char == '_'
 		})
 		if len(lq2) == 0 {
-			lqs = append(lqs, "en") // Fallback to english
-			return lqs
+			// Empty/malformed segment (e.g. a stray comma) - skip it instead
+			// of abandoning the languages that follow.
+			continue
 		}
 		lqs = append(lqs, parseLanguageCode(lq2[0]))
+	}
+
+	if len(lqs) == 0 {
+		// No valid language was parsed (empty or fully malformed header);
+		// fall back to english so callers always get a non-empty list.
+		lqs = append(lqs, "en")
 	}
 
 	return lqs

--- a/backend/utils/accept-language_test.go
+++ b/backend/utils/accept-language_test.go
@@ -1,8 +1,33 @@
 package utils
 
 import (
+	"reflect"
 	"testing"
 )
+
+// TestParseAcceptLanguageSkipsEmptySegments guards against the regression where
+// a malformed/empty segment caused the parser to abandon every language that
+// followed it (it used to `return` instead of `continue`).
+func TestParseAcceptLanguageSkipsEmptySegments(t *testing.T) {
+	got := ParseAcceptLanguage("en, , de")
+	want := []string{"en", "de"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseAcceptLanguage(\"en, , de\") = %v, want %v", got, want)
+	}
+}
+
+// TestParseAcceptLanguageFallsBackToEnglish ensures an empty or fully malformed
+// header still yields the english fallback, so callers (e.g. the audio/subtitle
+// language-preference middleware) never receive an empty preference list.
+func TestParseAcceptLanguageFallsBackToEnglish(t *testing.T) {
+	for _, header := range []string{"", "   ", ",", "-"} {
+		got := ParseAcceptLanguage(header)
+		want := []string{"en"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ParseAcceptLanguage(%q) = %v, want %v", header, got, want)
+		}
+	}
+}
 
 func TestParseAcceptLanguage(t *testing.T) {
 	t.Log("da, en-gb;q=0.8, en;q=0.7")

--- a/migrations/00358_translations_hash_last_sent_tz.sql
+++ b/migrations/00358_translations_hash_last_sent_tz.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- last_sent was a plain `timestamp` (without time zone) while ShouldSendTranslations
+-- compares it against NOW() (timestamptz). Under a non-UTC database session timezone
+-- that comparison is offset, which made the 30-minute dedup window behave differently
+-- in prod than locally. Store it as timestamptz so the comparison is unambiguous.
+ALTER TABLE translations_hash
+    ALTER COLUMN last_sent TYPE timestamptz USING last_sent AT TIME ZONE 'UTC';
+
+-- +goose Down
+
+ALTER TABLE translations_hash
+    ALTER COLUMN last_sent TYPE timestamp USING last_sent AT TIME ZONE 'UTC';

--- a/queries/calendar.sql
+++ b/queries/calendar.sql
@@ -147,5 +147,4 @@ FROM calendarentries_translations et
     JOIN calendarentries e ON e.id = et.calendarentries_id
 WHERE et.languages_code ='no'
   AND et.date_updated > @date_updated
-  AND e.date_updated > @date_updated
   AND e.status = ANY ('{published,unlisted}');

--- a/queries/translations.sql
+++ b/queries/translations.sql
@@ -62,16 +62,6 @@ VALUES (@item_id, @language, @title, @description)
 ON CONFLICT (events_id, languages_code) DO UPDATE SET title       = EXCLUDED.title,
                                                       description = EXCLUDED.description;
 
--- name: GetCalendarEntryTranslatable :many
-SELECT et.id,
-       calendarentries_id                                            as parent_id,
-       languages_code                                                as language,
-       json_build_object('title', title, 'description', description) as values
-FROM calendarentries_translations et
-         JOIN events e ON e.id = et.calendarentries_id
-WHERE et.languages_code = 'no'
-AND et.date_updated > @date_updated;
-
 -- name: UpdateCalendarEntryTranslation :exec
 INSERT INTO calendarentries_translations (calendarentries_id, languages_code, title, description)
 VALUES (@item_id, @language, @title, @description)
@@ -241,9 +231,6 @@ FROM translations_hash
 WHERE collection = @collection
   AND hash = @hash::bytea
   AND last_sent > NOW() - INTERVAL '30 minutes';
-
--- name: GetTranslationsHash :many
-SELECT * FROM translations_hash WHERE hash = @hash;
 
 -- name: UpdateTranslationsHash :exec
 INSERT INTO translations_hash (collection, hash)


### PR DESCRIPTION
Review of the translation system surfaced several bugs, the most impactful affecting events and calendar entries.

Sync path:
- Drop the global GetTranslationsHash check in sendToProviderIfNeeded. It looked up the hash across all collections with no time window and skipped whenever any row matched, so once a payload's hash was recorded an identical payload was never sent again. The table starts empty locally but is populated in prod, which is why sending silently stopped there. The per-collection 30-minute window (ShouldSendTranslations) is the intended dedup.
- Migration 00358 makes translations_hash.last_sent timestamptz so the 30-minute comparison against NOW() is timezone-safe.
- GetCalendarEntriesTranslatable no longer filters on the parent row's date_updated, so editing only a calendar entry's Norwegian translation re-exports it (matching the events query).
- Import handlers now capture and surface Update*Translation errors instead of silently dropping them.
- Carry survey-question description through export/import; decode achievement groups and FAQ categories with the same TitleTranslation shape they are exported with; handle (log+skip) previously-ignored json.Unmarshal errors on export; remove the dead, miswired GetCalendarEntryTranslatable query.

Resolve path:
- LocaleString/LocaleMap Get/GetValueOrNil no longer append onto the caller's languages slice (shared across concurrent resolvers -> data race); use a non-mutating withDefaults helper.
- Treat a valid-but-empty translation as missing so it falls through to a populated fallback language.
- ParseAcceptLanguage skips interior empty/malformed segments instead of abandoning the rest, while still falling back to english when nothing valid is parsed.

Regenerated sqlc (also drops stale EpisodesUsergroup* models for tables removed earlier). Adds unit tests for the resolver and parser changes plus an integration test for re-send after the dedup window.