### PR TITLE
feat(infra): stream-proxy live signing config + terraform-managed liv…

### DIFF
--- a/infra/api.tf
+++ b/infra/api.tf
@@ -9,6 +9,12 @@ locals {
   # rotated independently.
   ioriver_signing_key_path = "/secrets3/ioriver.pem"
 
+  # Live is a separate origin with its own signing identities, configured
+  # independently of the VOD keys above (no fallback). The live ioriver key is
+  # terraform-generated (see live-cdn.tf / stream-proxy.tf); only the direct-CF
+  # key is mounted from var.api_secret_files.
+  live_cf_signing_key_path = "/secrets5/live_cf.pem"
+
   # The livestream is signed with its own CloudFront key pair (separate from the
   # VOD/file key above). Mounted via the `livestream_signing_key` entry in
   # var.api_secret_files; LIVESTREAM_SIGNING_KEY_ID is supplied via var.api_env.

--- a/infra/live-cdn.tf
+++ b/infra/live-cdn.tf
@@ -1,0 +1,158 @@
+# Live delivery via ioriver vCDN (CloudFront + Fastly under ioriver-managed
+# tenancy — no provider credentials of our own). This is the `ioriver` half of
+# the stream-proxy live upstream; the direct-CloudFront half (/secrets5,
+# LIVE_CF_*) is provisioned outside terraform.
+#
+# Everything is gated on var.live_cdn (null in dev/sta): with it unset this
+# file creates nothing and the empty ioriver token is never used.
+
+locals {
+  live_cdn_enabled = var.live_cdn != null
+}
+
+# RSA key pair for live URL signing: the public half is registered with
+# ioriver, the private half is what stream-proxy signs with (delivered to the
+# service via Secret Manager below). Rotating = taint this resource.
+resource "tls_private_key" "live_ioriver_signing" {
+  count = local.live_cdn_enabled ? 1 : 0
+
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+# Required by the ioriver signing-key API alongside the RSA public key (used
+# for HMAC-style providers); stream-proxy only consumes it for Akamai, which
+# is not enabled here.
+resource "random_password" "live_ioriver_encryption_key" {
+  count = local.live_cdn_enabled ? 1 : 0
+
+  length  = 32
+  special = false
+}
+
+resource "ioriver_certificate" "live" {
+  count = local.live_cdn_enabled ? 1 : 0
+
+  name = "live-cdn"
+  type = "MANAGED"
+  cn   = var.live_cdn.hostname
+}
+
+resource "ioriver_service" "live" {
+  count = local.live_cdn_enabled ? 1 : 0
+
+  name        = "live-cdn"
+  description = "Livestream delivery (managed by terraform, bcc-media-platform/infra)"
+  certificate = ioriver_certificate.live[0].id
+
+  config = {
+    origins = [
+      {
+        name = "live-origin"
+        custom_origin = {
+          host     = var.live_cdn.origin_host
+          protocol = "https"
+        }
+      }
+    ]
+
+    domains = [
+      {
+        domain = var.live_cdn.hostname
+        mappings = [
+          { target_mapping = "live-origin" }
+        ]
+      }
+    ]
+
+    behaviors = {
+      default = {
+        actions = {
+          # Signed URLs only, and cache per the MediaPackage origin's
+          # Cache-Control (short for live manifests, long for segments).
+          url_signing          = true
+          origin_cache_control = true
+        }
+      }
+    }
+  }
+}
+
+# The backend-facing key ids land in provider_keys (map keyed "Cloudfront" /
+# "Fastly") and are wired straight into the stream-proxy env in
+# stream-proxy.tf — nothing to copy into tfvars.
+resource "ioriver_url_signing_key" "live" {
+  count = local.live_cdn_enabled ? 1 : 0
+
+  service        = ioriver_service.live[0].id
+  name           = "live-cdn"
+  public_key     = tls_private_key.live_ioriver_signing[0].public_key_pem
+  encryption_key = random_password.live_ioriver_encryption_key[0].result
+}
+
+# --- DNS (bcc-media zone in the shared DNS project) ---
+
+resource "google_dns_record_set" "live_cdn" {
+  count    = local.live_cdn_enabled ? 1 : 0
+  provider = google.dns
+
+  managed_zone = "bcc-media"
+  name         = "${var.live_cdn.hostname}."
+  type         = "CNAME"
+  ttl          = 300
+  rrdatas      = ["${trimsuffix(ioriver_service.live[0].cname, ".")}."]
+}
+
+# ACME validation for the MANAGED certificate. ioriver returns `challenges` as
+# a JSON-ish string (single-quoted); with a single-CN cert there is exactly one
+# challenge, and only its value is unknown before the first apply, so this
+# resolves in the same apply. If the format ever defeats the parse, the raw
+# string is in the certificate state — create the CNAME by hand.
+resource "google_dns_record_set" "live_cdn_acme" {
+  count    = local.live_cdn_enabled ? 1 : 0
+  provider = google.dns
+
+  managed_zone = "bcc-media"
+  name         = "_acme-challenge.${var.live_cdn.hostname}."
+  type         = "CNAME"
+  ttl          = 300
+  rrdatas = [
+    "${trimsuffix(jsondecode(replace(ioriver_certificate.live[0].challenges, "'", "\""))[0].value, ".")}."
+  ]
+}
+
+# --- Private signing key → stream-proxy (mounted in stream-proxy.tf) ---
+
+resource "google_secret_manager_secret" "live_ioriver_signing_key" {
+  count   = local.live_cdn_enabled ? 1 : 0
+  project = google_project.brunstadtv.project_id
+
+  secret_id = "live_ioriver_signing_key"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "live_ioriver_signing_key" {
+  count       = local.live_cdn_enabled ? 1 : 0
+  secret      = google_secret_manager_secret.live_ioriver_signing_key[0].id
+  secret_data = tls_private_key.live_ioriver_signing[0].private_key_pem
+}
+
+resource "google_secret_manager_secret_iam_member" "live_ioriver_signing_key_stream_proxy" {
+  count   = local.live_cdn_enabled ? 1 : 0
+  project = google_project.brunstadtv.project_id
+
+  secret_id = google_secret_manager_secret.live_ioriver_signing_key[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.stream_proxy.email}"
+}
+
+output "live_cdn_hostname" {
+  value = local.live_cdn_enabled ? var.live_cdn.hostname : null
+}
+
+output "live_ioriver_provider_keys" {
+  value     = local.live_cdn_enabled ? ioriver_url_signing_key.live[0].provider_keys : null
+  sensitive = true
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,6 +2,16 @@ locals {
   aws_region = "eu-north-1"
 }
 
+terraform {
+  required_providers {
+    # Non-hashicorp providers are not implicitly resolvable and must be declared.
+    ioriver = {
+      source  = "ioriver/ioriver"
+      version = "~> 1.4"
+    }
+  }
+}
+
 provider "aws" {
   region  = local.aws_region
   profile = var.aws_profile
@@ -20,6 +30,21 @@ provider "google" {
 
 provider "google-beta" {
   region = var.gcp-region
+}
+
+# DNS zones live in their own project (see the private infra repo's
+# projects/global/dns), so cross-project record sets need a dedicated provider.
+provider "google" {
+  alias   = "dns"
+  project = var.dns_project
+  region  = var.gcp-region
+}
+
+# Live-CDN ioriver account (separate account from the dashboard-managed VOD
+# one). The token is empty in envs where var.live_cdn is null — the provider
+# does not validate it until a resource actually calls the API.
+provider "ioriver" {
+  token = var.ioriver_live_token
 }
 
 module "vod_cdn" {

--- a/infra/stream-proxy.tf
+++ b/infra/stream-proxy.tf
@@ -8,6 +8,14 @@ locals {
   stream_proxy_ioriver_key_files = [
     for v in module.api_secret_files.data : v if v.name == local.ioriver_signing_key_path
   ]
+  stream_proxy_live_cf_key_files = [
+    for v in module.api_secret_files.data : v if v.name == local.live_cf_signing_key_path
+  ]
+
+  # The live ioriver signing key is generated in terraform (live-cdn.tf) rather
+  # than mounted from var.api_secret_files like the others; only the mount path
+  # is defined here.
+  live_ioriver_signing_key_path = "/secrets6/live_ioriver.pem"
 }
 
 resource "google_service_account" "stream_proxy" {
@@ -82,6 +90,42 @@ resource "google_cloud_run_service" "stream_proxy" {
           value = local.ioriver_signing_key_path
         }
 
+        env {
+          name  = "LIVE_CF_SIGNING_KEY_PATH"
+          value = local.live_cf_signing_key_path
+        }
+
+        env {
+          name  = "LIVE_IORIVER_SIGNING_KEY_PATH"
+          value = local.live_ioriver_signing_key_path
+        }
+
+        # Live ioriver upstream (live-cdn.tf): the hostname and the per-CDN
+        # signing key ids come straight from the ioriver resources.
+        dynamic "env" {
+          for_each = local.live_cdn_enabled ? [1] : []
+          content {
+            name  = "STREAM_PROXY_LIVE_CDN_DOMAIN_IORIVER"
+            value = var.live_cdn.hostname
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.live_cdn_enabled ? [1] : []
+          content {
+            name  = "LIVE_IORIVER_CLOUDFRONT_KEY_ID"
+            value = lookup(ioriver_url_signing_key.live[0].provider_keys, "Cloudfront", "")
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.live_cdn_enabled ? [1] : []
+          content {
+            name  = "LIVE_IORIVER_FASTLY_KEY_ID"
+            value = lookup(ioriver_url_signing_key.live[0].provider_keys, "Fastly", "")
+          }
+        }
+
         dynamic "env" {
           for_each = module.stream_proxy_secrets.data
           iterator = v
@@ -129,6 +173,24 @@ resource "google_cloud_run_service" "stream_proxy" {
             name       = v.value.secret_name
           }
         }
+
+        dynamic "volume_mounts" {
+          for_each = local.stream_proxy_live_cf_key_files
+          iterator = v
+          content {
+            mount_path = dirname(v.value.name)
+            name       = v.value.secret_name
+          }
+        }
+
+        dynamic "volume_mounts" {
+          for_each = google_secret_manager_secret.live_ioriver_signing_key
+          iterator = v
+          content {
+            mount_path = dirname(local.live_ioriver_signing_key_path)
+            name       = v.value.secret_id
+          }
+        }
       }
 
       dynamic "volumes" {
@@ -156,6 +218,36 @@ resource "google_cloud_run_service" "stream_proxy" {
             items {
               key  = "latest"
               path = basename(v.value.name)
+            }
+          }
+        }
+      }
+
+      dynamic "volumes" {
+        for_each = local.stream_proxy_live_cf_key_files
+        iterator = v
+        content {
+          name = v.value.secret_name
+          secret {
+            secret_name = v.value.secret_name
+            items {
+              key  = "latest"
+              path = basename(v.value.name)
+            }
+          }
+        }
+      }
+
+      dynamic "volumes" {
+        for_each = google_secret_manager_secret.live_ioriver_signing_key
+        iterator = v
+        content {
+          name = v.value.secret_id
+          secret {
+            secret_name = v.value.secret_id
+            items {
+              key  = "latest"
+              path = basename(local.live_ioriver_signing_key_path)
             }
           }
         }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -202,3 +202,25 @@ variable "admin_cors_origins" {
   description = "Comma-separated origin allowlist for the admin auth/GraphQL endpoints (admin-web origins). Must be same-site with the API host admin-web uses (api.bcc.media) for the refresh cookie to work."
   default     = "https://admin.app.bcc.media"
 }
+
+variable "live_cdn" {
+  type = object({
+    hostname    = string # e.g. live-cdn.bcc.media — becomes STREAM_PROXY_LIVE_CDN_DOMAIN_IORIVER
+    origin_host = string # live MediaPackage endpoint host
+  })
+  description = "Live ioriver vCDN config; null disables all live-cdn resources (dev/sta)."
+  default     = null
+}
+
+variable "ioriver_live_token" {
+  type        = string
+  description = "API token for the live-CDN ioriver account (separate account from VOD)."
+  sensitive   = true
+  default     = ""
+}
+
+variable "dns_project" {
+  type        = string
+  description = "GCP project holding the Cloud DNS zones (see the private infra repo's projects/global/dns)."
+  default     = "dns-managmenet"
+}


### PR DESCRIPTION
…e ioriver vCDN

Infra-only split of the live-proxy branch so it can merge and apply independently, ahead of the code changes. Safe against the currently deployed stream-proxy binary, which ignores the added env vars and mounts.

- stream-proxy: LIVE_CF/LIVE_IORIVER signing key paths, env and secret volumes for the live upstream (direct-CF key via api_secret_files at /secrets5/live_cf.pem; ioriver key terraform-generated below)
- live-cdn.tf: ioriver MANAGED certificate, service (MediaPackage origin, live domain, signed-URL default behavior honoring origin Cache-Control) and URL signing key on the separate live ioriver vCDN account; RSA pair generated in-state, private half delivered to stream-proxy via Secret Manager; per-CDN key ids (provider_keys) and hostname wired straight into the stream-proxy env
- DNS: live-cdn CNAME + ACME challenge in the bcc-media zone via an aliased google provider against the DNS project
- all live-cdn resources gated on var.live_cdn (null in dev/sta); the ioriver provider token is only used when resources exist