### PR TITLE
fix(version): stamp build_sha into the binary via buildvcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ tmp/*
 tmp
 dist
 .generated
-version.json
 key.local.rsa
 web/public/revision
 web/.crowdin_token

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -54,9 +54,7 @@ blocks:
           commands:
             - go get -v ./...
             - CI=true go test ./...
-            - scripts/gen-version.sh
-            - cp version.json ./backend
-            - CGO_ENABLED=0 go build -v -o ./backend/bin ./backend/cmd/api
+            - CGO_ENABLED=0 go build -buildvcs=true -v -o ./backend/bin ./backend/cmd/api
             - cd ./backend
             - 'docker build -t "europe-west4-docker.pkg.dev/utils-332514/btv-platform/api:${SEMAPHORE_GIT_SHA:0:7}" -t europe-west4-docker.pkg.dev/utils-332514/btv-platform/api:${SEMAPHORE_GIT_BRANCH//\//_} .'
             - 'docker push "europe-west4-docker.pkg.dev/utils-332514/btv-platform/api:${SEMAPHORE_GIT_SHA:0:7}"'
@@ -64,7 +62,7 @@ blocks:
             - 'echo "europe-west4-docker.pkg.dev/utils-332514/btv-platform/api:${SEMAPHORE_GIT_SHA:0:7}" > api.txt'
             - artifact push workflow api.txt
             - cd ..
-            - CGO_ENABLED=0 go build -v -o ./backend/bin ./backend/cmd/jobs
+            - CGO_ENABLED=0 go build -buildvcs=true -v -o ./backend/bin ./backend/cmd/jobs
             - cd ./backend
             - 'docker build -t "europe-west4-docker.pkg.dev/utils-332514/btv-platform/jobs:${SEMAPHORE_GIT_SHA:0:7}" -t europe-west4-docker.pkg.dev/utils-332514/btv-platform/jobs:${SEMAPHORE_GIT_BRANCH//\//_} .'
             - 'docker push "europe-west4-docker.pkg.dev/utils-332514/btv-platform/jobs:${SEMAPHORE_GIT_SHA:0:7}"'
@@ -72,7 +70,7 @@ blocks:
             - 'echo "europe-west4-docker.pkg.dev/utils-332514/btv-platform/jobs:${SEMAPHORE_GIT_SHA:0:7}" > jobs.txt'
             - artifact push workflow jobs.txt
             - cd ..
-            - CGO_ENABLED=0 go build -v -o ./backend/bin ./backend/cmd/rewriter
+            - CGO_ENABLED=0 go build -buildvcs=true -v -o ./backend/bin ./backend/cmd/rewriter
             - cd ./backend
             - 'docker build -t "europe-west4-docker.pkg.dev/utils-332514/btv-platform/rewriter:${SEMAPHORE_GIT_SHA:0:7}" -t europe-west4-docker.pkg.dev/utils-332514/btv-platform/rewriter:${SEMAPHORE_GIT_BRANCH//\//_} .'
             - 'docker push "europe-west4-docker.pkg.dev/utils-332514/btv-platform/rewriter:${SEMAPHORE_GIT_SHA:0:7}"'
@@ -80,7 +78,7 @@ blocks:
             - 'echo "europe-west4-docker.pkg.dev/utils-332514/btv-platform/rewriter:${SEMAPHORE_GIT_SHA:0:7}" > rewriter.txt'
             - artifact push workflow rewriter.txt
             - cd ..
-            - CGO_ENABLED=0 go build -v -o ./backend/bin ./backend/cmd/videomanipulator
+            - CGO_ENABLED=0 go build -buildvcs=true -v -o ./backend/bin ./backend/cmd/videomanipulator
             - cd ./backend
             - 'docker build -f Dockerfile.ffmpeg -t "europe-west4-docker.pkg.dev/utils-332514/btv-platform/videomanipulator:${SEMAPHORE_GIT_SHA:0:7}" -t europe-west4-docker.pkg.dev/utils-332514/btv-platform/videomanipulator:${SEMAPHORE_GIT_BRANCH//\//_} .'
             - 'docker push "europe-west4-docker.pkg.dev/utils-332514/btv-platform/videomanipulator:${SEMAPHORE_GIT_SHA:0:7}"'
@@ -88,7 +86,7 @@ blocks:
             - 'echo "europe-west4-docker.pkg.dev/utils-332514/btv-platform/videomanipulator:${SEMAPHORE_GIT_SHA:0:7}" > videomanipulator.txt'
             - artifact push workflow videomanipulator.txt
             - cd ..
-            - CGO_ENABLED=0 go build -v -o ./backend/bin ./backend/cmd/stream-proxy
+            - CGO_ENABLED=0 go build -buildvcs=true -v -o ./backend/bin ./backend/cmd/stream-proxy
             - cd ./backend
             - 'docker build -t "europe-west4-docker.pkg.dev/utils-332514/btv-platform/stream-proxy:${SEMAPHORE_GIT_SHA:0:7}" -t europe-west4-docker.pkg.dev/utils-332514/btv-platform/stream-proxy:${SEMAPHORE_GIT_BRANCH//\//_} .'
             - 'docker push "europe-west4-docker.pkg.dev/utils-332514/btv-platform/stream-proxy:${SEMAPHORE_GIT_SHA:0:7}"'
@@ -105,8 +103,6 @@ blocks:
         - name: build
           commands:
             - checkout
-            - scripts/gen-version.sh
-            - cp version.json ./migrations
             - cd migrations
             - 'docker build -t "europe-west4-docker.pkg.dev/utils-332514/btv-platform/migrations:${SEMAPHORE_GIT_SHA:0:7}" -t europe-west4-docker.pkg.dev/utils-332514/btv-platform/migrations:${SEMAPHORE_GIT_BRANCH//\//_} .'
             - 'docker push "europe-west4-docker.pkg.dev/utils-332514/btv-platform/migrations:${SEMAPHORE_GIT_SHA:0:7}" '

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,3 @@
 FROM gcr.io/distroless/static AS prod
-COPY version.json /
 COPY bin /app
 CMD ["/app"]

--- a/backend/Dockerfile.api.test
+++ b/backend/Dockerfile.api.test
@@ -4,7 +4,7 @@ COPY go.mod /app/
 COPY go.sum /app/
 RUN go mod download
 COPY ./backend ./backend
-RUN go build -v -o ./backend/bin ./backend/cmd/api
+RUN go build -buildvcs=false -v -o ./backend/bin ./backend/cmd/api
 
 FROM alpine:3.16 AS runner
 COPY --from=builder ./app/backend/bin /app

--- a/backend/Dockerfile.ffmpeg
+++ b/backend/Dockerfile.ffmpeg
@@ -1,5 +1,4 @@
 FROM alpine:latest
-COPY version.json /
 COPY bin /app
 RUN apk update
 RUN apk add --no-cache ffmpeg

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -15,7 +15,7 @@ generate: sqlc/.generated gql
 build: dist/api dist/jobs dist/pubsub-helper
 
 dist/api dist/jobs dist/pubsub-helper: ./**/*.go sqlc/.generated
-	CGO_ENABLED=0 go build -v -o $@ ./cmd/$(@F)
+	CGO_ENABLED=0 go build -buildvcs=true -v -o $@ ./cmd/$(@F)
 
 sqlc/.generated: ../migrations/*.sql
 	go tool github.com/sqlc-dev/sqlc/cmd/sqlc generate

--- a/backend/version/handler.go
+++ b/backend/version/handler.go
@@ -1,51 +1,63 @@
 package version
 
 import (
-	"encoding/json"
+	"net/http"
+	"runtime/debug"
+
 	"github.com/bcc-code/bcc-media-platform/backend/graph/public/model"
 	"github.com/bcc-code/bcc-media-platform/backend/log"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"os"
-	"path"
-	"path/filepath"
 )
 
 var version = &model.Version{}
 
-// We find the first `version.json` based on the current CWD and working towards the root.
+// The build sha is stamped into the binary by the go toolchain (-buildvcs), so it
+// requires no files next to the binary and no knowledge of the working directory.
 func init() {
-	pwd, err := os.Getwd()
-	if err != nil {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		log.L.Warn().Msg("No build info available, build_sha will be empty")
 		return
 	}
 
-	root := "/"
-	// This should prevent infinite loops on windows especially!
-	// Not tested
-	if filepath.VolumeName(pwd) != "" {
-		root = filepath.VolumeName(pwd)
-	}
-
-	for pwd != root {
-		jsonPath := path.Join(pwd, "version.json")
-		pwd = path.Clean(path.Join(pwd, ".."))
-
-		// File not present, descend
-		if _, err := os.Stat(jsonPath); err != nil {
-			continue
-		}
-
-		jsonBytes, err := os.ReadFile(jsonPath)
-		if err != nil {
-			return
-		}
-
-		if err := json.Unmarshal(jsonBytes, version); err != nil {
-			log.L.Warn().Err(err).Str("path", jsonPath).Msg("Failed to parse version.json")
-		}
+	sha := shaFromSettings(info.Settings)
+	if sha == "" {
+		log.L.Warn().Msg("Binary built without VCS stamping, build_sha will be empty")
 		return
 	}
+
+	version.BuildSha = sha
+}
+
+// shaFromSettings extracts the short revision from the build settings, suffixed with
+// `-dirty` if the working tree was modified at build time. Empty if not stamped.
+func shaFromSettings(settings []debug.BuildSetting) string {
+	var revision string
+	var modified bool
+
+	for _, s := range settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+
+	if revision == "" {
+		return ""
+	}
+
+	// Matches the ${SEMAPHORE_GIT_SHA:0:7} tags the images are published under.
+	if len(revision) > 7 {
+		revision = revision[:7]
+	}
+
+	if modified {
+		revision += "-dirty"
+	}
+
+	return revision
 }
 
 // GinHandler returns a json string with the version data

--- a/backend/version/handler_test.go
+++ b/backend/version/handler_test.go
@@ -1,0 +1,54 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func Test_shaFromSettings(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings []debug.BuildSetting
+		expected string
+	}{
+		{
+			name:     "no settings",
+			settings: nil,
+			expected: "",
+		},
+		{
+			name:     "no vcs.revision",
+			settings: []debug.BuildSetting{{Key: "vcs.modified", Value: "true"}},
+			expected: "",
+		},
+		{
+			name: "full sha is shortened",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "3e4c8d3b1f2a4c5d6e7f8091a2b3c4d5e6f70819"},
+				{Key: "vcs.modified", Value: "false"},
+			},
+			expected: "3e4c8d3",
+		},
+		{
+			name: "modified tree is marked dirty",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "3e4c8d3b1f2a4c5d6e7f8091a2b3c4d5e6f70819"},
+				{Key: "vcs.modified", Value: "true"},
+			},
+			expected: "3e4c8d3-dirty",
+		},
+		{
+			name:     "short revision is left alone",
+			settings: []debug.BuildSetting{{Key: "vcs.revision", Value: "3e4c8d"}},
+			expected: "3e4c8d",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shaFromSettings(test.settings); got != test.expected {
+				t.Errorf("shaFromSettings() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}

--- a/scripts/gen-version.sh
+++ b/scripts/gen-version.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sed -ibak s/DEVELOP/$(git rev-parse --short HEAD)/g version.json

--- a/version.json
+++ b/version.json
@@ -1,3 +1,0 @@
-{
-  "build_sha": "DEVELOP"
-}


### PR DESCRIPTION
## Problem

`GET /versionz` returns `{"build_sha": ""}` in every deployed container (api, jobs, rewriter, videomanipulator, stream-proxy), and the GraphQL `Version.build_sha` field with it. The web client silently falls back to `'unknown | debug'`, which is what it reports as the analytics `releaseVersion`.

The value was read at runtime from a `version.json`: CI sed'd the short sha into it (`scripts/gen-version.sh`), copied it next to the binary, and the Dockerfiles did `COPY version.json /`. The loader then walked up from the process CWD:

```go
root := "/"
for pwd != root {   // CWD is "/" in the image → body never runs
    jsonPath := path.Join(pwd, "version.json")
    ...
}
```

The images set no `WORKDIR`, so CWD is `/` and the loop exits before its first iteration — `/version.json` is never stat'ed. It was broken twice over: the walk moves `pwd` to the parent *before* the stat check, so the root directory of any walk is never examined; adding a `WORKDIR` would not have fixed it either.

## Fix

Drop the sidecar file and let the Go toolchain stamp the revision into the binary — `debug.ReadBuildInfo()` exposes `vcs.revision` and `vcs.modified`, which `-buildvcs` records automatically for main packages built inside a git checkout (exactly how CI builds). No file next to the binary, no CWD dependency, nothing to keep in sync.

- `backend/version/handler.go` — read from build info; shorten to 7 chars to match the `${SEMAPHORE_GIT_SHA:0:7}` image tags; append `-dirty` when the tree was modified. Warn-log when stamping is absent instead of returning an empty value silently.
- `.semaphore/semaphore.yml`, `backend/Makefile` — `-buildvcs=true` on release builds, so a build without VCS info fails rather than shipping a blank sha. `backend/Dockerfile.api.test` builds inside a container with no `.git` and is pinned to `-buildvcs=false`.
- Removed `scripts/gen-version.sh`, `version.json`, the `cp version.json` CI steps, and the `COPY version.json /` lines.

`/versionz` and the GraphQL field keep their exact response shape.

## Testing

- `go build ./...`, `go vet ./version/`, `go test ./version/` pass.
- New `shaFromSettings` table test covers shortening, the `-dirty` suffix, and the unstamped case. (`debug.ReadBuildInfo()` reports no VCS settings under `go test`, so `init()` itself can't be asserted directly.)
- Reproduced the original failure case: built the rewriter with `-buildvcs=true`, ran it with CWD `/`, and `curl localhost:8099/versionz` returned `{"build_sha":"3e4c8d3-dirty"}`, matching `git rev-parse --short=7 HEAD` (`-dirty` from unrelated local edits).
- The Docker build was not run locally; the change there is only a removed `COPY` line.

Worth confirming after this lands on dev: `/versionz` should report the sha matching the deployed image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)