### PR TITLE
feat(api): structured access log middleware

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -266,7 +266,7 @@ func main() {
 	}
 	r := gin.New()
 
-	r.Use(gin.Logger())
+	r.Use(commonMiddleware.AccessLogMiddleware())
 	r.Use(gin.CustomRecovery(panicHandler))
 
 	r.Use(utils.GinContextToContextMiddleware())

--- a/backend/middleware/access_log.go
+++ b/backend/middleware/access_log.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/bcc-code/bcc-media-platform/backend/common"
+	"github.com/bcc-code/bcc-media-platform/backend/log"
+	"github.com/gin-gonic/gin"
+)
+
+// AccessLogMiddleware logs a structured line per request, including the
+// resolved application code when ApplicationMiddleware has run.
+func AccessLogMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+
+		ev := log.L.Info().
+			Str("method", c.Request.Method).
+			Str("path", c.Request.URL.Path).
+			Int("status", c.Writer.Status()).
+			Dur("latency", time.Since(start)).
+			Str("clientIP", c.ClientIP())
+		if app, err := common.GetApplicationFromCtx(c); err == nil && app != nil && app.Code != "" {
+			ev = ev.Str("applicationCode", app.Code)
+		}
+		if len(c.Errors) > 0 {
+			ev = ev.Str("errors", c.Errors.String())
+		}
+		ev.Msg("request")
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces `gin.Logger()` in cmd/api with a zerolog-based `AccessLogMiddleware`
- Logs one structured line per request: method, path, status, latency, client IP
- Includes the resolved `applicationCode` when ApplicationMiddleware has run, and any gin context errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)